### PR TITLE
Replace deprecated darken() with color.scale() for input focus border

### DIFF
--- a/style/_vanillaMagicSystem.scss
+++ b/style/_vanillaMagicSystem.scss
@@ -97,7 +97,7 @@
 
       &:focus {
         outline: none;
-        border-color: darken($vanilla-primary-color, 10%);
+        border-color: color.scale($vanilla-primary-color, $lightness: -10%);
         background-color: rgba(255, 255, 255, 0.7);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
       }


### PR DESCRIPTION
### Motivation
- Modernize SCSS usage and fix issues caused by the deprecated `darken()` function by switching to the `color.scale()` API.

### Description
- Replace `darken($vanilla-primary-color, 10%)` with `color.scale($vanilla-primary-color, $lightness: -10%)` in `style/_vanillaMagicSystem.scss` for the input `:focus` border color.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774199573c832ca8a79277a4e3a3d8)