### PR TITLE
Migrate legacy scripts to TSX and fix DOM initialization & asset paths

### DIFF
--- a/DATEI_DOKUMENTATION.md
+++ b/DATEI_DOKUMENTATION.md
@@ -40,56 +40,56 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 - **charbogen/InfoListe.json**
   - Datenquelle für Rassen- und Klassenlisten, strukturiert nach Kategorien. Wird beim Laden der Seite in Dropdowns übernommen.
 
-## Ordner `script/`
+## Ordner `src/script/`
 
 ### Kernlogik für Charakterbogen
 
-- **script/adjustments.js**
+- **src/script/adjustments.tsx**
   - Enthält Standard-Steigerungswerte (z. B. Attribute, Magie, Talente) und passt diese dynamisch an die gewählte Klassenkategorie an.
-- **script/calculations.js**
+- **src/script/calculations.tsx**
   - Berechnet abgeleitete Werte (LP, AUSD, MB, ASP, MR, Giftresistenz, Basiswerte etc.) aus Eingaben und synchronisiert Steigerungspunkte mit dem Magiesystem. Enthält zudem die automatische Skill-Verteilung.
-- **script/characterAttributes.js**
+- **src/script/characterAttributes.tsx**
   - Generiert die dynamischen UI-Abschnitte für Attribute/Talente (inkl. Kampf-Talente) und befüllt bestehende Container. Verantwortlich für das Rendern von Eingabefeldern und Tooltips.
-- **script/characterInfo.js**
+- **src/script/characterInfo.tsx**
   - Lädt und speichert die Charakter-Stammdaten (Name, Alter, Klasse usw.) zwischen JSON und UI.
-- **script/inputListeners.js**
+- **src/script/inputListeners.tsx**
   - Verwaltet Event-Listener für automatische Berechnungen und Steigerungspunkte. Enthält Funktionen zum Setzen von Min/Max-Werten für Eingabefelder.
-- **script/hideButtons.js**
+- **src/script/hideButtons.tsx**
   - Ermöglicht das Ausblenden einzelner Eingabefelder und verschiebt sie in den Tab „Ausgeblendete“, inkl. Wiederherstellungsfunktion.
 
 ### Magie- und Zaubersystem
 
-- **script/vanillaMagicSystem.js**
+- **src/script/vanillaMagicSystem.tsx**
   - Implementiert das Magiesystem: Datenmodelle, UI-Rendering, Steigerungskosten, Element-Anforderungen, Synchronisierung mit dem Charakterbogen sowie Speichern/Laden.
 
 ### Speichern/Laden und Datenfluss
 
-- **script/saveLoader.js**
+- **src/script/saveLoader.tsx**
   - Zentrales Speicher-/Ladesystem für Charakterdaten. Migriert ältere Magiestrukturen, synchronisiert Inventar, Geldbeutel, Magiesystem und Charakterwerte, und erzeugt JSON-Downloads.
 
 ### Inventar/Shop
 
-- **script/shop.js**
+- **src/script/shop.tsx**
   - Lädt Shop-Daten aus `shopData.json`, rendert Kategorien/Items, verwaltet Käufe, Inventar und Wallet-Umrechnung.
 
 ### Werkzeuge (Würfel & Rechner)
 
-- **script/dice.js**
+- **src/script/dice.tsx**
   - Würfelsystem mit Anzeige der Würfelergebnisse als SVG-Oktaeder, inklusive Sonderlogik (z. B. d20/d100 Auswahl).
-- **script/spezialDice.js**
+- **src/script/spezialDice.tsx**
   - Experimentelles Skript für „gute/schlechte“ Würfel-Logik (derzeit nur Logging).
-- **script/rechner.js**
+- **src/script/rechner.tsx**
   - Einfacher Taschenrechner im Werkzeuge-Tab (String-Ausdruck + `eval`).
 
 ### UI/UX & Komfort
 
-- **script/tabs.js**
+- **src/script/tabs.tsx**
   - Tab-Steuerung der Oberfläche und Logik für den „Ausgeblendete“-Tab.
-- **script/skin.js**
+- **src/script/skin.tsx**
   - Anpassungen für Schriftart und Textfarbe im UI.
-- **script/wallet.js**
+- **src/script/wallet.tsx**
   - Wallet-/Währungsverwaltung (Dukaten, Silber, Heller, Kreuzer) inkl. Anzeige und Umrechnung.
-- **script/liste.js**
+- **src/script/liste.tsx**
   - Lädt `InfoListe.json` und füllt die Dropdowns für Rassen und Klassen, inklusive Klassenkategorien für Steigerungsanpassungen.
 
 ## Ordner `style/`

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -26,6 +26,7 @@ const invokeLegacy = (name: string, ...args: unknown[]) => {
 
 const Tabs = () => {
   const [activeTab, setActiveTab] = useState<TabKey>("charakter");
+  const baseUrl = import.meta.env.BASE_URL ?? "/";
 
   return (
     <div className="tabs-container">
@@ -51,7 +52,7 @@ const Tabs = () => {
               <button type="button" id="saveButton">
                 Speichern
               </button>
-              <a href="./charbogen/charakter.json" download="charakter.json">
+              <a href={`${baseUrl}charbogen/charakter.json`} download="charakter.json">
                 Neue JSON-Datei herunterladen
               </a>
               <label htmlFor="filenameInput">Dateiname:</label>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,22 +11,22 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 
 const loadLegacyScripts = async () => {
   await Promise.all([
-    import("./script/rechner.js"),
-    import("./script/dice.js"),
-    import("./script/adjustments.js"),
-    import("./script/calculations.js"),
-    import("./script/inputListeners.js"),
-    import("./script/characterInfo.js"),
-    import("./script/wallet.js"),
-    import("./script/characterAttributes.js"),
-    import("./script/hideButtons.js"),
-    import("./script/liste.js"),
-    import("./script/spezialDice.js"),
-    import("./script/shop.js"),
-    import("./script/skin.js"),
-    import("./script/tabs.js"),
-    import("./script/vanillaMagicSystem.js"),
-    import("./script/saveLoader.js"),
+    import("./script/rechner.tsx"),
+    import("./script/dice.tsx"),
+    import("./script/adjustments.tsx"),
+    import("./script/calculations.tsx"),
+    import("./script/inputListeners.tsx"),
+    import("./script/characterInfo.tsx"),
+    import("./script/wallet.tsx"),
+    import("./script/characterAttributes.tsx"),
+    import("./script/hideButtons.tsx"),
+    import("./script/liste.tsx"),
+    import("./script/spezialDice.tsx"),
+    import("./script/shop.tsx"),
+    import("./script/skin.tsx"),
+    import("./script/tabs.tsx"),
+    import("./script/vanillaMagicSystem.tsx"),
+    import("./script/saveLoader.tsx"),
   ]);
 };
 

--- a/src/script/adjustments.tsx
+++ b/src/script/adjustments.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // adjustments.js
 
 // Objekt für Steigerungswerte

--- a/src/script/calculations.tsx
+++ b/src/script/calculations.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // calculations.js - Angepasst für das neue Magie-System
 
 function updateCharakterCalculation() {

--- a/src/script/characterAttributes.tsx
+++ b/src/script/characterAttributes.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // characterAttributes.js
 let kampfArr = []
 function generateCharakterAttributes(data) {

--- a/src/script/characterInfo.tsx
+++ b/src/script/characterInfo.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // characterInfo.js
 
 function genCharInfo(data) {

--- a/src/script/dice.tsx
+++ b/src/script/dice.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 //dice.js
 "use strict";
 

--- a/src/script/hideButtons.tsx
+++ b/src/script/hideButtons.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // hideButtons.js
 
 function bindHideButtons() {

--- a/src/script/inputListeners.tsx
+++ b/src/script/inputListeners.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // inputListeners.js
 
 function addInputChangeListeners() {

--- a/src/script/liste.tsx
+++ b/src/script/liste.tsx
@@ -1,6 +1,8 @@
+// @ts-nocheck
 // Laden der JSON-Daten und Initialisierung
-document.addEventListener('DOMContentLoaded', () => {
-    fetch('../charbogen/InfoListe.json')
+const initializeListe = () => {
+    const baseUrl = import.meta.env.BASE_URL ?? "/";
+    fetch(`${baseUrl}charbogen/InfoListe.json`)
         .then(response => {
             if (!response.ok) {
                 throw new Error('Netzwerkantwort war nicht ok');
@@ -59,4 +61,10 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         })
         .catch(error => console.error('Error fetching JSON:', error));
-});
+};
+
+if (document.readyState === "loading") {
+    document.addEventListener('DOMContentLoaded', initializeListe);
+} else {
+    initializeListe();
+}

--- a/src/script/rechner.tsx
+++ b/src/script/rechner.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 "use strict";
 
 function InToHTML(operation) {

--- a/src/script/saveLoader.tsx
+++ b/src/script/saveLoader.tsx
@@ -1,26 +1,32 @@
+// @ts-nocheck
 // ANLEITUNG:
-// 1. Erstellen Sie eine neue Datei namens "saveLoader.js" im "script"-Verzeichnis
+// 1. Erstellen Sie eine neue Datei namens "saveLoader.tsx" im "src/script"-Verzeichnis
 // 2. Kopieren Sie den gesamten unten stehenden Code in diese Datei
 // 3. Entfernen Sie aus Ihrer index.html jede Zeile mit:
 //    - "saveChanges.js"
 //    - "fileReader.js" 
 //    - "unifiedSaveSystem.js"
 // 4. Fügen Sie stattdessen am Ende Ihrer Script-Tags ein:
-//    <script src="./script/saveLoader.js"></script>
+//    <script src="./script/saveLoader.tsx"></script>
 
-// saveLoader.js - Einheitliches Speicher- und Ladesystem
+// saveLoader.tsx - Einheitliches Speicher- und Ladesystem
 
 // Globale Variablen
 let myData = null;
 let fileName = null;
 
-// Warte auf DOM-Bereitschaft
-document.addEventListener('DOMContentLoaded', function() {
+const initializeSaveLoader = () => {
     console.log("SaveLoader: Initialisiere Speicher- und Ladesystem...");
-    
+
     // Initialisiere Event-Listener
     setupEventListeners();
-});
+};
+
+if (document.readyState === "loading") {
+    document.addEventListener('DOMContentLoaded', initializeSaveLoader);
+} else {
+    initializeSaveLoader();
+}
 
 // Einrichtung der Event-Listener
 function setupEventListeners() {

--- a/src/script/shop.tsx
+++ b/src/script/shop.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Komplette shop.js Datei
 let inventory = [];
 let shopData = {};
@@ -5,7 +6,8 @@ let shopData = {};
 // Funktion, um Shop-Daten zu laden
 async function loadShopData() {
     try {
-        const response = await fetch("shopData.json");
+        const baseUrl = import.meta.env.BASE_URL ?? "/";
+        const response = await fetch(`${baseUrl}shopData.json`);
         if (!response.ok) {
             throw new Error(`Fehler beim Laden der Shop-Daten: ${response.statusText}`);
         }

--- a/src/script/skin.tsx
+++ b/src/script/skin.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 function changeFont() {
     const font = document.getElementById("fontInput").value;
     if (font) {

--- a/src/script/spezialDice.tsx
+++ b/src/script/spezialDice.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 let dice1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
 let dice1Length = dice1.length

--- a/src/script/tabs.tsx
+++ b/src/script/tabs.tsx
@@ -1,6 +1,7 @@
+// @ts-nocheck
 // tabs.js
 
-document.addEventListener('DOMContentLoaded', function() {
+const initializeTabs = () => {
     // Tab functionality
     const tabItems = document.querySelectorAll('.tab-item');
     const tabContents = document.querySelectorAll('.tab-content');
@@ -49,4 +50,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (tabItems.length > 0) {
         tabItems[0].click();
     }
-});
+};
+
+if (document.readyState === "loading") {
+    document.addEventListener('DOMContentLoaded', initializeTabs);
+} else {
+    initializeTabs();
+}

--- a/src/script/vanillaMagicSystem.tsx
+++ b/src/script/vanillaMagicSystem.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // script/vanillaMagicSystem.js - Verbesserte Version mit zuverlässigem Speichern und Laden
 
 // Magiedaten
@@ -1055,7 +1056,7 @@ function debugMagicSystem() {
 }
 
 // Tab-Wechsel-Erkennung und Initialisierung
-document.addEventListener('DOMContentLoaded', function() {
+const initializeMagicSystemTab = () => {
     // *** VERBESSERT: Initialisiere MagicSystem zuerst ***
     MagicSystem.init();
     
@@ -1122,7 +1123,13 @@ document.addEventListener('DOMContentLoaded', function() {
             setTimeout(debugMagicSystem, 200);
         }, 300);
     }
-});
+};
+
+if (document.readyState === "loading") {
+    document.addEventListener('DOMContentLoaded', initializeMagicSystemTab);
+} else {
+    initializeMagicSystemTab();
+}
 
 // Funktion zum Initialisieren des Systems nach DOM-Manipulation
 function initializeVanillaMagicSystem() {

--- a/src/script/wallet.tsx
+++ b/src/script/wallet.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // wallet.js
 
 let wallet = {


### PR DESCRIPTION
### Motivation
- File loading and save/load flows stopped working because legacy scripts were loaded/executed in a way that missed proper initialization timing in the Vite/React app. 
- The app still referenced legacy `.js` assets and relative fetch/download paths that do not respect Vite's `BASE_URL`, causing failed fetches/downloads when served. 
- Converting to module imports and ensuring initialization occurs after DOM readiness restores predictable behavior for the legacy logic inside the React app.

### Description
- Renamed legacy script files under `src/script/` from `.js` to `.tsx` and added dynamic imports in `src/main.tsx` to load them as modules. 
- Added `// @ts-nocheck` headers to migrated files to avoid TypeScript errors while keeping the original plain-JS logic. 
- Replaced bare `DOMContentLoaded` listeners with guarded initializer functions that check `document.readyState` and attach a `DOMContentLoaded` handler only if needed (e.g., `src/script/saveLoader.tsx`, `src/script/tabs.tsx`, `src/script/vanillaMagicSystem.tsx`, `src/script/liste.tsx`). 
- Normalized asset and JSON fetch/download URLs to use `import.meta.env.BASE_URL` (updated `src/script/liste.tsx`, `src/script/shop.tsx`, and `src/components/Tabs.tsx`) and updated `DATEI_DOKUMENTATION.md` to reflect the new `src/script/*.tsx` paths.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775dfa6b20832c9917528f268037f3)