### PR TITLE
Fix magic system refresh after JSON load

### DIFF
--- a/src/script/saveLoader.tsx
+++ b/src/script/saveLoader.tsx
@@ -568,11 +568,18 @@ function loadMagieSystem(data) {
                     });
                 }
                 
+                const magieTab = document.getElementById('magie-tab');
+                if (magieTab &&
+                    !magieTab.querySelector('.vanilla-magic-system') &&
+                    typeof window.initializeVanillaMagicSystem === 'function') {
+                    window.initializeVanillaMagicSystem();
+                }
+
                 // UI aktualisieren, falls verfügbar
                 if (typeof window.renderMagicList === 'function') {
                     window.renderMagicList();
                 }
-                
+
                 if (typeof window.updatePreview === 'function') {
                     window.updatePreview();
                 }
@@ -598,6 +605,13 @@ function loadMagieSystem(data) {
                     window.advancementPoints = 0;
                 }
                 
+                const magieTab = document.getElementById('magie-tab');
+                if (magieTab &&
+                    !magieTab.querySelector('.vanilla-magic-system') &&
+                    typeof window.initializeVanillaMagicSystem === 'function') {
+                    window.initializeVanillaMagicSystem();
+                }
+
                 // 3. Versuche die UI zu aktualisieren
                 if (typeof window.renderMagicList === 'function') {
                     window.renderMagicList();
@@ -605,7 +619,7 @@ function loadMagieSystem(data) {
                 } else {
                     console.warn("SaveLoader: renderMagicList Funktion nicht verfügbar");
                 }
-                
+
                 if (typeof window.updatePreview === 'function') {
                     window.updatePreview();
                     console.log("SaveLoader: Vorschau aktualisiert");

--- a/src/script/vanillaMagicSystem.tsx
+++ b/src/script/vanillaMagicSystem.tsx
@@ -399,6 +399,41 @@ function initVanillaMagicSystem() {
         const loadButton = document.getElementById('loadButton');
         const fileInput = document.getElementById('fileInput');
         const previewContent = document.getElementById('previewContent');
+
+        const requiredElements = [
+            elementSelect,
+            customElementContainer,
+            customElementInput,
+            magicTypeSelect,
+            magicLevelInput,
+            levelErrorDiv,
+            addMagicBtn,
+            magicListDiv,
+            addPointsBtn,
+            characterNameInput,
+            loadButton,
+            fileInput,
+            previewContent
+        ];
+
+        if (requiredElements.some((element) => !element)) {
+            console.error("VanillaMagicSystem: Fehlende DOM-Elemente, Initialisierung abgebrochen", {
+                elementSelect,
+                customElementContainer,
+                customElementInput,
+                magicTypeSelect,
+                magicLevelInput,
+                levelErrorDiv,
+                addMagicBtn,
+                magicListDiv,
+                addPointsBtn,
+                characterNameInput,
+                loadButton,
+                fileInput,
+                previewContent
+            });
+            return;
+        }
         
         // Populiere die Select-Elemente
         populateSelectElements();
@@ -410,7 +445,7 @@ function initVanillaMagicSystem() {
         
         // *** VERBESSERT: Speicherschaltfläche neu verknüpfen mit der Hauptspeicherfunktion ***
         const parentSaveButton = document.getElementById('saveButton');
-        if (parentSaveButton) {
+        if (parentSaveButton && saveButton) {
             console.log("Verbesserter Save-Button gefunden und neu verknüpft");
             saveButton.addEventListener('click', function() {
                 // Sicherstellen, dass die globalen Variablen aktuell sind
@@ -421,7 +456,7 @@ function initVanillaMagicSystem() {
                 
                 console.log("Hauptspeicherfunktion aufgerufen");
             });
-        } else {
+        } else if (saveButton) {
             // Fallback zum selbstständigen Speichern
             saveButton.addEventListener('click', saveCharacter);
         }
@@ -1063,6 +1098,7 @@ const initializeMagicSystemTab = () => {
     // Setze globale Funktionen für andere Skripte
     window.renderMagicList = renderMagicList;
     window.updatePreview = updatePreview;
+    window.initializeVanillaMagicSystem = initializeVanillaMagicSystem;
     
     // Tab-Wechsel erkennen und Synchronisation auslösen
     const tabItems = document.querySelectorAll('.tab-item');


### PR DESCRIPTION
### Motivation
- Loading a JSON file could call magic-system routines before the magic UI was built, causing silent failures or errors from missing DOM nodes during the TSX refactor.
- The magic system and saveloader needed to be made robust to the new render lifecycle introduced by converting the app to TSX and patched tab content handling.
- The goal is to ensure the magic UI is initialized when required and that list/preview updates run reliably after a file load.

### Description
- Add a DOM presence guard in `initVanillaMagicSystem` that aborts initialization early when required elements are missing to avoid runtime errors (check for `elementSelect`, `magic-list`, `previewContent`, etc.).
- Expose the initializer as `window.initializeVanillaMagicSystem` so other modules can trigger UI setup when needed.
- Update `loadMagieSystem` in `src/script/saveLoader.tsx` to call `initializeVanillaMagicSystem` if the `magie-tab` exists but the `.vanilla-magic-system` UI has not yet been appended, and then call `renderMagicList` and `updatePreview` to keep UI in sync.
- Improve save-button re-linking logic in the vanilla magic system to only rewire when both the local and parent save button elements are present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c143ad28832ca691ebc6b9b237f2)