### PR TITLE
Add Vitest smoke tests, test scripts, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier . --write",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -23,17 +25,21 @@
     "@vitejs/plugin-react": "^4.3.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "husky": "^9.1.7",
+    "jsdom": "^26.1.0",
     "lint-staged": "^15.2.11",
     "prettier": "^3.5.3",
     "sass": "^1.78.0",
     "typescript": "^5.6.3",
-    "vite": "^5.4.10"
+    "vite": "^5.4.10",
+    "vitest": "^3.2.4"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import App from "../App";
+
+describe("App", () => {
+  it("renders the main controls and tabs", () => {
+    render(<App />);
+
+    expect(screen.getByRole("button", { name: "Automatische Umrechnung" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Charakter" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Magie" })).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Tabs.test.tsx
+++ b/src/__tests__/Tabs.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Tabs from "../components/Tabs";
+import { CharacterProvider } from "../features/character";
+
+describe("Tabs", () => {
+  it("shows the tab navigation and default content", () => {
+    render(
+      <CharacterProvider>
+        <Tabs
+          listenersEnabled
+          hiddenItemsVisible={false}
+          magicState={{ advancementPoints: 0, magicAbilities: [] }}
+          onMagicChange={vi.fn()}
+        />
+      </CharacterProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "Charakter" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Inventar & Shop" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Charakterinformation" })).toBeInTheDocument();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,8 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+  },
 });


### PR DESCRIPTION
### Motivation
- Provide a lightweight test harness and initial smoke tests for core UI so regressions in `App` and `Tabs` are caught early.
- Wire up `vitest`/`@testing-library/react` with a `jsdom` environment to enable React component tests.
- Ensure CI runs linting, type checking and tests on push/PR to catch issues before merging.

### Description
- Add `test` and `test:watch` scripts and dev dependencies for `vitest`, `@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` in `package.json` and add `vitest` to `devDependencies`.
- Configure Vite test environment in `vite.config.ts` with `test.environment: "jsdom"` and `setupFiles: "./src/test/setup.ts"` and add `src/test/setup.ts` to import `@testing-library/jest-dom`.
- Add smoke tests `src/__tests__/App.test.tsx` and `src/__tests__/Tabs.test.tsx` to assert main controls and tab navigation render correctly.
- Add a GitHub Actions workflow `.github/workflows/ci.yml` that runs `npm ci`, `npm run lint`, `npm run typecheck`, and `npm run test` on push and pull requests.

### Testing
- The new smoke tests `src/__tests__/App.test.tsx` and `src/__tests__/Tabs.test.tsx` were added but not executed in this environment.
- Attempted to install test dependencies with `npm install -D vitest @testing-library/react @testing-library/jest-dom jsdom`, which failed due to a `403 Forbidden` response from the npm registry, preventing local test execution.
- The CI workflow was added to run `npm ci` then `npm run lint`, `npm run typecheck`, and `npm run test`; these steps will execute in CI once registry access is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a15fbdd08832c925020faaee4b9f9)