### PR TITLE
Add Node test harness and unit tests for character utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b",
+    "test": "rm -rf dist-tests && tsc -p tsconfig.test.json && node scripts/patch-test-imports.mjs && node --test dist-tests",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/scripts/patch-test-imports.mjs
+++ b/scripts/patch-test-imports.mjs
@@ -1,0 +1,55 @@
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { join, extname } from "node:path";
+
+const root = new URL("../dist-tests", import.meta.url);
+
+const shouldRewrite = (specifier) => {
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+    return false;
+  }
+  const extension = extname(specifier);
+  return extension === "";
+};
+
+const rewriteSpecifiers = (content) => {
+  const fromRegex = /(from\s+["'])([^"']+)(["'])/g;
+  const importRegex = /(import\(\s*["'])([^"']+)(["']\s*\))/g;
+
+  const rewrite = (_match, prefix, specifier, suffix) => {
+    if (!shouldRewrite(specifier)) {
+      return `${prefix}${specifier}${suffix}`;
+    }
+    return `${prefix}${specifier}.js${suffix}`;
+  };
+
+  return content.replace(fromRegex, rewrite).replace(importRegex, rewrite);
+};
+
+const patchFile = async (filePath) => {
+  const content = await readFile(filePath, "utf-8");
+  const updated = rewriteSpecifiers(content);
+  if (updated !== content) {
+    await writeFile(filePath, updated, "utf-8");
+  }
+};
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+        return;
+      }
+      if (entry.isFile() && entry.name.endsWith(".js")) {
+        await patchFile(entryPath);
+      }
+    })
+  );
+};
+
+const stats = await stat(root);
+if (stats.isDirectory()) {
+  await walk(root.pathname);
+}

--- a/src/features/character/components/CharacterAttributes.tsx
+++ b/src/features/character/components/CharacterAttributes.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { applyMaxValueSettings } from "../services/maxValueSettings";
 
 type TalentEntry = {
     Name: string;
@@ -27,38 +28,6 @@ type Props = {
     // optional: externe Funktionen aus deinem Projekt
     saveChanges?: (data: CharakterData) => void;
     addInputChangeListeners?: () => void;
-};
-
-export const applyMaxValueSettings = (level: number, MB: number) => {
-    const talentInputs = document.querySelectorAll<HTMLInputElement>(
-        ".Assassinen_Talente, .Talente_1, .Talente_2, .Handwerkstalente, .Kampf_Talente"
-    );
-
-    talentInputs.forEach((input) => {
-        input.max = String(Math.min(level + 10, 21));
-        input.min = String(-3);
-    });
-
-    const attrInputs = document.querySelectorAll<HTMLInputElement>(".attribute");
-    attrInputs.forEach((input) => {
-        input.max = String(Math.min(level + 12, 21));
-        input.min = String(7);
-    });
-
-    const magicInputs = document.querySelectorAll<HTMLInputElement>(".Magische_Elemente");
-    magicInputs.forEach((input) => {
-        input.max = String(Math.min(MB / 2, 21));
-        input.min = String(0);
-    });
-
-    const modifierInputs = document.querySelectorAll<HTMLInputElement>(".modifier");
-    modifierInputs.forEach((input) => {
-        input.max = String(level + 2);
-        input.min = String(0);
-    });
-
-    const xp = document.querySelector<HTMLInputElement>("#erfahrung_xp");
-    if (xp) xp.step = "100";
 };
 
 export default function CharacterAttributes({

--- a/src/features/character/services/calculations.ts
+++ b/src/features/character/services/calculations.ts
@@ -1,6 +1,6 @@
 // calculations.js - Angepasst für das neue Magie-System
 import { readNumericInput, writeDerivedValue, writeInputValue } from "./characterState";
-import { applyMaxValueSettings } from "../components/CharacterAttributes";
+import { applyMaxValueSettings } from "./maxValueSettings";
 import type { MagicAbility } from "../../../types/character";
 
 const getInputElement = (id: string) => {

--- a/src/features/character/services/maxValueSettings.ts
+++ b/src/features/character/services/maxValueSettings.ts
@@ -1,0 +1,31 @@
+export const applyMaxValueSettings = (level: number, MB: number) => {
+  const talentInputs = document.querySelectorAll<HTMLInputElement>(
+    ".Assassinen_Talente, .Talente_1, .Talente_2, .Handwerkstalente, .Kampf_Talente"
+  );
+
+  talentInputs.forEach((input) => {
+    input.max = String(Math.min(level + 10, 21));
+    input.min = String(-3);
+  });
+
+  const attrInputs = document.querySelectorAll<HTMLInputElement>(".attribute");
+  attrInputs.forEach((input) => {
+    input.max = String(Math.min(level + 12, 21));
+    input.min = String(7);
+  });
+
+  const magicInputs = document.querySelectorAll<HTMLInputElement>(".Magische_Elemente");
+  magicInputs.forEach((input) => {
+    input.max = String(Math.min(MB / 2, 21));
+    input.min = String(0);
+  });
+
+  const modifierInputs = document.querySelectorAll<HTMLInputElement>(".modifier");
+  modifierInputs.forEach((input) => {
+    input.max = String(level + 2);
+    input.min = String(0);
+  });
+
+  const xp = document.querySelector<HTMLInputElement>("#erfahrung_xp");
+  if (xp) xp.step = "100";
+};

--- a/src/features/shop/services/shop.ts
+++ b/src/features/shop/services/shop.ts
@@ -12,7 +12,7 @@ const syncInventoryToWindow = () => {
 // Funktion, um Shop-Daten zu laden
 async function loadShopData() {
     try {
-        const baseUrl = import.meta.env.BASE_URL ?? "/";
+        const baseUrl = import.meta.env?.BASE_URL ?? "/";
         const response = await fetch(`${baseUrl}shopData.json`);
         if (!response.ok) {
             throw new Error(`Fehler beim Laden der Shop-Daten: ${response.statusText}`);
@@ -165,7 +165,10 @@ export function renderInventory() {
     updateWalletDisplay();
 }
 
-loadShopData();
+const canLoadShopData = typeof window !== "undefined" && typeof document !== "undefined" && typeof fetch === "function";
+if (canLoadShopData) {
+    void loadShopData();
+}
 
 const shopButton = document.getElementById("ShopButton");
 const shopContainer = document.getElementById("shop");

--- a/tests/adjustments.test.ts
+++ b/tests/adjustments.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("resetAdjustmentsToDefault restores defaults", async () => {
+  (globalThis as { document?: unknown; HTMLInputElement?: unknown }).document = {
+    querySelectorAll: () => [],
+    getElementById: () => null,
+  };
+  (globalThis as { HTMLInputElement?: unknown }).HTMLInputElement = class {};
+
+  const adjustmentsModule = await import("../src/features/character/services/adjustments.js");
+  const { adjustments, resetAdjustmentsToDefault } = adjustmentsModule;
+
+  adjustments.modifier_magie = 1;
+  adjustments.Handwerkstalente = 1;
+  resetAdjustmentsToDefault();
+
+  assert.equal(adjustments.modifier_magie, 10);
+  assert.equal(adjustments.Handwerkstalente, 3);
+});
+
+test("setKlassenVariable applies class adjustments", async () => {
+  (globalThis as { document?: unknown; HTMLInputElement?: unknown }).document = {
+    querySelectorAll: () => [],
+    getElementById: () => null,
+  };
+  (globalThis as { HTMLInputElement?: unknown }).HTMLInputElement = class {};
+
+  const adjustmentsModule = await import("../src/features/character/services/adjustments.js");
+  const { adjustments, setKlassenVariable, resetAdjustmentsToDefault } = adjustmentsModule;
+
+  resetAdjustmentsToDefault();
+  setKlassenVariable("Mage", {
+    "Magische Klassen": ["Mage"],
+  });
+
+  assert.equal(adjustments.modifier_magie, 3);
+  assert.equal(adjustments.modifier_asp, 5);
+  assert.equal(adjustments.Magische_Elemente, 20);
+});

--- a/tests/node-ambient.d.ts
+++ b/tests/node-ambient.d.ts
@@ -1,0 +1,23 @@
+declare module "node:test" {
+  type TestCallback = () => void | Promise<void>;
+  const test: (name: string, fn: TestCallback) => void;
+  export default test;
+}
+
+declare module "node:assert/strict" {
+  interface ThrowsOptions {
+    message?: string | RegExp;
+  }
+
+  const assert: {
+    ok: (value: unknown, message?: string) => void;
+    equal: (actual: unknown, expected: unknown, message?: string) => void;
+    throws: (fn: () => unknown, options?: ThrowsOptions) => void;
+  };
+
+  export default assert;
+}
+
+declare module "react-dom/server" {
+  export const renderToStaticMarkup: (element: unknown) => string;
+}

--- a/tests/saveLoader.test.ts
+++ b/tests/saveLoader.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const setupDom = () => {
+  (globalThis as { document?: unknown }).document = {
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+  (globalThis as { HTMLInputElement?: unknown }).HTMLInputElement = class {};
+  (globalThis as { HTMLSelectElement?: unknown }).HTMLSelectElement = class {};
+};
+
+test("generateStandardFilename sanitizes the character name", async () => {
+  setupDom();
+  const { generateStandardFilename } = await import("../src/features/character/services/saveLoader.js");
+
+  const filename = generateStandardFilename("Mein Name@ 2024!");
+
+  assert.ok(filename.startsWith("Mein_Name_2024_"));
+  assert.ok(filename.endsWith(".json"));
+  assert.ok(!filename.includes("@"));
+  assert.ok(!filename.includes("!"));
+});
+
+test("generateStandardFilename falls back to default name", async () => {
+  setupDom();
+  const { generateStandardFilename } = await import("../src/features/character/services/saveLoader.js");
+
+  const filename = generateStandardFilename("   ");
+
+  assert.ok(filename.startsWith("Charakter_"));
+  assert.ok(filename.endsWith(".json"));
+});

--- a/tests/vite-env.d.ts
+++ b/tests/vite-env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly [key: string]: string | boolean | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": false,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "outDir": "dist-tests",
+    "rootDir": ".",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["tests"]
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight Node-based test harness to run core unit tests outside the browser and CI-friendly environments. 
- Add deterministic unit coverage for character-related utilities that previously required DOM or browser globals. 
- Prevent runtime side-effects (shop data fetch / DOM usage) from breaking tests by guarding browser-only behavior.

### Description

- Added a Node test configuration file `tsconfig.test.json` and ambient shims in `tests/node-ambient.d.ts` to compile and run tests with Node ESM. 
- Introduced `scripts/patch-test-imports.mjs` which post-processes compiled ESM files to ensure import specifiers resolve correctly when running tests from `dist-tests`. 
- Added unit tests under `tests/` covering `src/features/character/services/adjustments.ts` and `src/features/character/services/saveLoader.ts` as `tests/adjustments.test.ts` and `tests/saveLoader.test.ts`. 
- Extracted `applyMaxValueSettings` into `src/features/character/services/maxValueSettings.ts`, updated consumers to import it, and guarded shop data loading (fetch) in `src/features/shop/services/shop.ts` for non-browser environments. 
- Updated `package.json` `test` script to compile tests and run the Node test runner using the new helper script and test configuration.

### Testing

- Ran the automated test command `npm test` which invokes `tsc -p tsconfig.test.json` then runs the compiled tests; the test run completed with all tests passing. 
- Tests executed: `tests/adjustments.test.ts` (covers `resetAdjustmentsToDefault` and `setKlassenVariable`) and `tests/saveLoader.test.ts` (covers `generateStandardFilename`), and both suites passed. 
- The compilation step `tsc -p tsconfig.test.json` completed successfully as part of the `npm test` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a1a18bfe8832cbdb820df06ab20b8)