### PR TITLE
Step 4: Move hide buttons and min/max to React state

### DIFF
--- a/DATEI_DOKUMENTATION.md
+++ b/DATEI_DOKUMENTATION.md
@@ -92,10 +92,22 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
   - UI für Laden/Speichern (Datei-Upload und Download).
 - **src/features/character/components/CharacterAttributes.tsx**
   - React-Komponente zum Rendern der Attribut- und Talent-Abschnitte aus JSON-Daten.
+- **src/features/character/components/AttributesSection.tsx**
+  - React-Komponente für die Attribut-Eingaben (React-State).
+- **src/features/character/components/ModifiersSection.tsx**
+  - React-Komponente für Modifier-Eingaben (React-State).
+- **src/features/character/components/CombatBaseSection.tsx**
+  - React-Komponente für Kampf-Basiswerte (abgeleitete Werte).
+- **src/features/character/components/SonderwerteSection.tsx**
+  - React-Komponente für Sonderwerte (abgeleitete Werte).
+- **src/features/character/components/HiddenAttributesSection.tsx**
+  - React-Komponente für ausgeblendete Attribute (Ausgeblendete-Tab).
 - **src/features/character/index.ts**
   - Sammel-Exports für Context, UI-Teile und Save/Load-Helfer.
 - **src/features/character/legacy.ts**
   - Lädt die bisherigen DOM-basierten Services (Übergangscode).
+- **src/features/character/hooks/useCharacterCalculations.ts**
+  - Hook für React-State-Berechnungen der Kernwerte (Attribute/Modifier → abgeleitete Werte).
 
 #### Charakter-Services (`src/features/character/services/`)
 
@@ -105,6 +117,8 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
   - Berechnung abgeleiteter Werte (LP, AUSD, MB, ASP, MR, Giftresistenz) sowie Auto-Skill-Verteilung.
 - **characterInfo.ts**
   - Laden/Speichern der Stammdaten (Name, Alter, Klasse usw.).
+- **derivedCalculations.ts**
+  - Pure Berechnungsfunktionen für Level- und Derived-Values (React/Legacy gemeinsam nutzbar).
 - **characterState.ts**
   - Zentrale Brücke zwischen Eingaben und berechneten Ausgaben (DOM-Input/Output).
 - **hideButtons.ts**
@@ -187,13 +201,59 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 - Magiesystem als React-Komponente (inkl. Typed State).
 - Charakterdaten-Speichern/-Laden (inkl. Migrationspfade) ist in TypeScript-Services vorhanden.
 - Shop/Würfel/Rechner-Logik wurde in Services ausgelagert und aus React heraus angesteuert.
+- Legacy-Abhängigkeiten inventarisiert (Codex-Aufgabe 1) inkl. Skript zur Wiederholung der Analyse.
+- Erste React-State-Berechnungen für Kernattribute/Modifier inkl. abgeleiteter Basis-/Sonderwerte umgesetzt (Codex-Aufgabe 2 gestartet).
+- UI-Abschnitte für Attribute/Modifier/Sonderwerte/Kampf-Basiswerte in React-Komponenten ausgelagert (Codex-Aufgabe 3 gestartet).
+- Hide-Buttons/Min-Max-Aktionen für Attribute/Modifier nach React-State überführt (Codex-Aufgabe 4 gestartet).
 
 ### Was noch zu migrieren ist (weil aktuell noch Legacy-Skripte benötigt werden)
 
-- **DOM-Logik in `services/` → React-State/Komponenten:** Charakterberechnungen, Listener, Hide-Buttons, Tabs, Wallet und Shop hängen noch direkt am DOM.
-- **UI-Abschnitte mit Legacy-IDs:** Viele Inputs/Container werden noch per ID gesucht (z. B. `attribute_*`, `shop`, `inventory`). Diese müssten in React-Components überführt werden.
+- **DOM-Logik in `services/` → React-State/Komponenten:** Charakterberechnungen, Listener, Tabs, Wallet und Shop hängen noch direkt am DOM.
+- **UI-Abschnitte mit Legacy-IDs:** Attribute/Modifier/Sonderwerte/Kampf-Basiswerte sind als React-Komponenten gerendert; weitere Bereiche (Talente, Shop, Inventar) hängen noch an Legacy-IDs und müssen migriert werden.
 - **Global-Funktionen auf `window`:** Tabs rufen Legacy-Funktionen wie `Roll`, `TheChoosenOne`, `updateCharakterCalculation` usw. auf. Das sollte in lokale Hooks/Services umgebaut werden.
 - **Datei-Import/Export an React binden:** Save/Load ist bereits ausgelagert, aber die UI ist noch Teil des großen Tab-Markups; eine saubere Trennung in eigenständige Komponenten fehlt.
+- **Restliche Charakterberechnungen migrieren:** Talente/Gesteigerte-Logik, Auto-Skill-Verteilung und Listener/MaxValue-Logik außerhalb der Attribute/Modifier sind noch Legacy-basiert.
+
+### Inventarisierte Legacy-Abhängigkeiten (Codex-Aufgabe 1)
+
+Für eine reproduzierbare Analyse kann das Skript `scripts/legacy-deps-inventory.mjs` genutzt werden. Es erzeugt `legacy-deps-report.json` im Repo-Root mit einer Feature-Übersicht (window-Globals, DOM-IDs, Selektoren, DOM-Operationen).
+
+**Core (src/main.tsx)**
+- DOM-IDs: `root`
+- DOM-Operationen: `createRoot`, `getElementById`
+
+**Character (src/features/character/… )**
+- window-Globals: `MagicSystem`, `advancementPoints`, `characterMagic`, `inventory`, `kampfArr`
+- DOM-IDs (statisch):
+  - Charakterinfo: `name`, `alter`, `geschlecht`, `rassen-select`, `klassen-select`, `größe`, `gewicht`, `haarfarbe`, `augenfarbe`, `titel`
+  - Erfahrung/Werte: `erfahrung_xp`, `erfahrung_level`, `erfahrung_Steigerungspunkte`, `erfahrung_Gesteigerte`
+  - Attribute/Modifier: `modifier_lp`, `modifier_asp`, `modifier_magie`, `modifier_fernkampf`, `modifier_nahkampf`, `modifier_gift`
+  - Attribute-Eingaben: `attribute_Körperkraft`, `attribute_Gewandheit`, `attribute_Klugheit`, `attribute_Intuition`, `attribute_Fingerfertigkeit`, `attribute_Charisma`, `attribute_Geschicklichkeit`, `attribute_Tarnung`, `attribute_Sinnesschärfe`, `attribute_Willenskraft`, `attribute_Konstitution`
+  - Sonderwerte/Basiswerte: `sonderwerte_Maximale_LP`, `sonderwerte_Maximale_Ausdauer`, `sonderwerte_Magiebegabung`, `sonderwerte_Maximale_Astralenergie`, `sonderwerte_Magieresistenz`, `sonderwerte_Giftresistenz`, `sonderwerte_Schnelligkeit`, `KampfBasiswerte_Wurfwaffen_Basiswert`, `KampfBasiswerte_Schusswaffen_Basiswert`, `KampfBasiswerte_Attacke_Basiswert`, `KampfBasiswerte_Parade_Basiswert`
+  - Auto-Skill/Buttons: `ASkillVert`, `setMin`, `setMax`, `toggleListenersCheckbox`, `toggleHiddenCheckbox`
+  - Containers/Legacy-UI: `modifierContainer`, `sonderwerteContainer`, `attributeContainer`, `magischeElementeContainer`, `kampfTalenteGridContainer`, `hiddenItemsContainer`, `saveButton`
+  - Magie-Tooltip-IDs: `Magische_Elemente_Schatten_Tooltip`, `Magische_Elemente_Licht_Tooltip`, `Magische_Elemente_Holz_Tooltip`, `Magische_Elemente_Metall_Tooltip`, `Magische_Elemente_Eis_Tooltip`, `Magische_Elemente_Leben_Tooltip`, `Magische_Elemente_Nekromantie_Tooltip`, `Magische_Elemente_Blitz_Tooltip`, `Magische_Elemente_Gravitation_Tooltip`, `Magische_Elemente_Erschaffung_Tooltip`, `Magische_Elemente_Raumzeit_Tooltip`, `Magische_Elemente_Gift_Tooltip`, `Magische_Elemente_Blut_Tooltip`
+  - Kampf-Talent-IDs (fixiert genutzt): `Kampf_Talente_Schild_0`, `Kampf_Talente_Schild_1`, `Kampf_Talente_Schild_2`, `Kampf_Talente_Wurfwaffen_0`, `Kampf_Talente_Wurfwaffen_1`, `Kampf_Talente_Wurfwaffen_2`, `Kampf_Talente_Bolzenwaffen_0`, `Kampf_Talente_Bolzenwaffen_1`, `Kampf_Talente_Bolzenwaffen_2`, `Kampf_Talente_Pfeilwaffen_0`, `Kampf_Talente_Pfeilwaffen_1`, `Kampf_Talente_Pfeilwaffen_2`
+  - Dynamische IDs/Template-IDs: `${sectionId}_${sanitizedKey}_${index}`, `${sectionId}_${sanitizedKey}`
+  - Magic/Shop-Synchronisierung: `advancement-points`, `inventory`
+- DOM-Selektoren: `.stg`, `.hidden-items`, `.tab-item`, `.tab-content`, `.hidebutton`, `.FlexItem`, `.BigFlexItem`, `.hidden-item`, `.Assassinen_Talente`, `.Talente_1`, `.Talente_2`, `.Handwerkstalente`, `.Kampf_Talente`, `.attribute`, `.Magische_Elemente`, `.modifier`, `#inventory li`, `label`, `select`, `input`
+- Direkte DOM-Operationen: `getElementById`, `querySelector(All)`, `createElement`, `appendChild`, `removeChild`, `classList`, `style`, `innerHTML`, `textContent`, `setAttribute`, `addEventListener`, `removeEventListener`, `closest`
+
+**Magic (src/features/magic/… )**
+- window-Globals: `MagicSystem`, `advancementPoints`, `characterMagic`, `renderMagicList`, `updatePreview`
+- DOM-IDs: `erfahrung_level`, `erfahrung_xp`, `erfahrung_Gesteigerte`, `erfahrung_Steigerungspunkte`, `advancement-points`, `name`, `characterName`, `elementSelect`, `customElementContainer`, `customElement`, `magicTypeSelect`, `magicLevel`, `levelError`, `addMagicBtn`, `magic-list`, `add-points-btn`, `saveButton`, `loadButton`, `fileInput`, `previewContent`, `magie-tab`, `magieSpeichernButton`
+- DOM-Selektoren: `.tab-item`, `.btn-level-up`, `.btn-remove`, `.vanilla-magic-system`
+- Direkte DOM-Operationen: `getElementById`, `querySelector(All)`, `createElement`, `appendChild`, `removeChild`, `classList`, `style`, `innerHTML`, `textContent`, `setAttribute`, `addEventListener`, `dispatchEvent`
+
+**Shop (src/features/shop/… )**
+- window-Globals: `inventory`
+- DOM-IDs: `shop`, `itemNameInput`, `inventory`, `ShopButton`, `showDukaten`, `showSilber`, `showHeller`, `showKreuzer`, `CurrencyField`, `NumberInput`
+- DOM-Selektoren: `#inventory li`
+- Direkte DOM-Operationen: `getElementById`, `createElement`, `appendChild`, `classList`, `innerHTML`, `textContent`, `addEventListener`
+
+**Dice (src/features/dice/… )**
+- DOM-IDs: `divDice`, `DiceCount`, `DiceSides`, `showDice`, `container`, `Dicer`, `eqField`, `evField`
+- Direkte DOM-Operationen: `getElementById`, `createElementNS`, `appendChild`, `classList`, `style`, `innerHTML`, `innerText`, `setAttribute`
 
 ### Hinweis zum aktuellen Stand
 

--- a/legacy-deps-report.json
+++ b/legacy-deps-report.json
@@ -1,0 +1,220 @@
+{
+  "character": {
+    "files": [
+      "src/features/character/CharacterContext.tsx",
+      "src/features/character/CharacterNameInput.tsx",
+      "src/features/character/ExperienceSection.tsx",
+      "src/features/character/SaveControls.tsx",
+      "src/features/character/components/AttributesSection.tsx",
+      "src/features/character/components/CharacterAttributes.tsx",
+      "src/features/character/components/CombatBaseSection.tsx",
+      "src/features/character/components/HiddenAttributesSection.tsx",
+      "src/features/character/components/ModifiersSection.tsx",
+      "src/features/character/components/SonderwerteSection.tsx",
+      "src/features/character/hooks/useCharacterCalculations.ts",
+      "src/features/character/index.ts",
+      "src/features/character/legacy.ts",
+      "src/features/character/services/adjustments.ts",
+      "src/features/character/services/calculations.ts",
+      "src/features/character/services/characterInfo.ts",
+      "src/features/character/services/characterState.ts",
+      "src/features/character/services/derivedCalculations.ts",
+      "src/features/character/services/hideButtons.ts",
+      "src/features/character/services/inputListeners.ts",
+      "src/features/character/services/liste.ts",
+      "src/features/character/services/maxValueSettings.ts",
+      "src/features/character/services/saveLoader.ts",
+      "src/features/character/services/skin.ts",
+      "src/features/character/services/tabs.ts"
+    ],
+    "windowGlobals": [
+      "MagicSystem",
+      "advancementPoints",
+      "characterMagic",
+      "inventory",
+      "kampfArr"
+    ],
+    "domIds": [
+      "${sectionId}_${key}",
+      "${sectionId}_${sanitizedKey}",
+      "${sectionId}_${sanitizedKey}_${index}",
+      "ASkillVert",
+      "advancement-points",
+      "attributeContainer",
+      "colorInput",
+      "erfahrung_Gesteigerte",
+      "erfahrung_Steigerungspunkte",
+      "fontInput",
+      "hiddenItemsContainer",
+      "kampfTalenteGridContainer",
+      "klassen-select",
+      "magischeElementeContainer",
+      "modifierContainer",
+      "rassen-select",
+      "saveButton",
+      "setMax",
+      "setMin",
+      "sonderwerteContainer",
+      "toggleHiddenCheckbox",
+      "toggleListenersCheckbox"
+    ],
+    "domIdTemplates": [
+      "template:${sectionId}_${key}",
+      "template:${sectionId}_${sanitizedKey}",
+      "template:${sectionId}_${sanitizedKey}_${index}"
+    ],
+    "selectors": [
+      "#erfahrung_xp",
+      "#inventory li",
+      ".${klass}",
+      ".Assassinen_Talente, .Talente_1, .Talente_2, .Handwerkstalente, .Kampf_Talente",
+      ".Magische_Elemente",
+      ".attribute",
+      ".hidden-items",
+      ".hidebutton",
+      ".modifier",
+      ".stg",
+      ".tab-content",
+      ".tab-item",
+      "h6",
+      "input",
+      "input[min][max]",
+      "label",
+      "select"
+    ],
+    "domOperations": [
+      "addEventListener",
+      "appendChild",
+      "classList",
+      "closest",
+      "createElement",
+      "getElementById",
+      "innerHTML",
+      "querySelector",
+      "querySelectorAll",
+      "removeChild",
+      "removeEventListener",
+      "setAttribute",
+      "style",
+      "textContent"
+    ]
+  },
+  "dice": {
+    "files": [
+      "src/features/dice/index.ts",
+      "src/features/dice/legacy.ts",
+      "src/features/dice/services/dice.ts",
+      "src/features/dice/services/rechner.ts",
+      "src/features/dice/services/spezialDice.ts"
+    ],
+    "windowGlobals": [],
+    "domIds": [
+      "Dicer",
+      "eqField",
+      "evField"
+    ],
+    "domIdTemplates": [],
+    "selectors": [],
+    "domOperations": [
+      "appendChild",
+      "classList",
+      "createElementNS",
+      "getElementById",
+      "innerHTML",
+      "innerText",
+      "setAttribute",
+      "style",
+      "textContent"
+    ]
+  },
+  "magic": {
+    "files": [
+      "src/features/magic/VanillaMagicSystem.tsx",
+      "src/features/magic/services/vanillaMagicSystem.ts",
+      "src/features/magic/types.ts"
+    ],
+    "windowGlobals": [
+      "MagicSystem",
+      "advancementPoints",
+      "characterMagic",
+      "prompt",
+      "renderMagicList",
+      "updatePreview"
+    ],
+    "domIds": [
+      "advancement-points",
+      "magie-tab",
+      "saveButton"
+    ],
+    "domIdTemplates": [],
+    "selectors": [
+      ".btn-level-up",
+      ".btn-remove",
+      ".tab-item",
+      ".vanilla-magic-system"
+    ],
+    "domOperations": [
+      "addEventListener",
+      "appendChild",
+      "classList",
+      "createElement",
+      "dispatchEvent",
+      "getElementById",
+      "innerHTML",
+      "querySelector",
+      "querySelectorAll",
+      "removeChild",
+      "textContent"
+    ]
+  },
+  "shop": {
+    "files": [
+      "src/features/shop/index.ts",
+      "src/features/shop/legacy.ts",
+      "src/features/shop/services/shop.ts",
+      "src/features/shop/services/wallet.ts"
+    ],
+    "windowGlobals": [
+      "inventory"
+    ],
+    "domIds": [
+      "CurrencyField",
+      "NumberInput",
+      "ShopButton",
+      "inventory",
+      "itemNameInput",
+      "shop",
+      "showDukaten",
+      "showHeller",
+      "showKreuzer",
+      "showSilber"
+    ],
+    "domIdTemplates": [],
+    "selectors": [],
+    "domOperations": [
+      "addEventListener",
+      "appendChild",
+      "classList",
+      "createElement",
+      "getElementById",
+      "innerHTML",
+      "innerText",
+      "textContent"
+    ]
+  },
+  "core": {
+    "files": [
+      "src/main.tsx"
+    ],
+    "windowGlobals": [],
+    "domIds": [
+      "root"
+    ],
+    "domIdTemplates": [],
+    "selectors": [],
+    "domOperations": [
+      "createRoot",
+      "getElementById"
+    ]
+  }
+}

--- a/scripts/legacy-deps-inventory.mjs
+++ b/scripts/legacy-deps-inventory.mjs
@@ -1,0 +1,175 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const rootDir = process.cwd();
+const srcDir = path.join(rootDir, "src");
+const featuresDir = path.join(srcDir, "features");
+const mainEntry = path.join(srcDir, "main.tsx");
+
+const allowedExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"]);
+
+const domOperationPatterns = [
+  { label: "addEventListener", regex: /\.addEventListener\(/ },
+  { label: "removeEventListener", regex: /\.removeEventListener\(/ },
+  { label: "dispatchEvent", regex: /\.dispatchEvent\(/ },
+  { label: "createElement", regex: /document\.createElement\(/ },
+  { label: "createElementNS", regex: /document\.createElementNS\(/ },
+  { label: "createRoot", regex: /createRoot\(/ },
+  { label: "appendChild", regex: /\.appendChild\(/ },
+  { label: "removeChild", regex: /\.removeChild\(/ },
+  { label: "innerHTML", regex: /\.innerHTML\s*=/ },
+  { label: "textContent", regex: /\.textContent\s*=/ },
+  { label: "innerText", regex: /\.innerText\s*=/ },
+  { label: "style", regex: /\.style\./ },
+  { label: "classList", regex: /\.classList\./ },
+  { label: "setAttribute", regex: /\.setAttribute\(/ },
+  { label: "removeAttribute", regex: /\.removeAttribute\(/ },
+  { label: "closest", regex: /\.closest\(/ },
+  { label: "append", regex: /\.append\(/ },
+  { label: "querySelector", regex: /\.querySelector\(/ },
+  { label: "querySelectorAll", regex: /\.querySelectorAll\(/ },
+  { label: "getElementById", regex: /getElementById\(/ },
+];
+
+const getFeatureName = (filePath) => {
+  const normalized = filePath.replace(/\\/g, "/");
+  const marker = "/src/features/";
+  const idx = normalized.indexOf(marker);
+  if (idx === -1) {
+    return "core";
+  }
+  const remainder = normalized.slice(idx + marker.length);
+  return remainder.split("/")[0] || "core";
+};
+
+const walkDir = async (dir, files = []) => {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkDir(fullPath, files);
+      continue;
+    }
+    if (!allowedExtensions.has(path.extname(entry.name))) {
+      continue;
+    }
+    files.push(fullPath);
+  }
+  return files;
+};
+
+const collectMatches = (content, regex, transform = (match) => match) => {
+  const results = [];
+  let match;
+  const globalRegex = new RegExp(regex.source, `${regex.flags}g`);
+  while ((match = globalRegex.exec(content)) !== null) {
+    results.push(transform(match));
+  }
+  return results;
+};
+
+const summarizeFile = (content) => {
+  const windowGlobals = new Set(
+    collectMatches(content, /window\.([A-Za-z0-9_$]+)/, (match) => match[1])
+  );
+
+  const domIds = new Set(
+    collectMatches(content, /getElementById\(\s*['"`]([^'"`]+)['"`]\s*\)/, (match) => match[1])
+  );
+
+  const domIdTemplates = new Set(
+    collectMatches(content, /getElementById\(\s*`([^`]+)`\s*\)/, (match) => match[1])
+      .filter((template) => template.includes("${"))
+      .map((template) => `template:${template}`)
+  );
+
+  const selectors = new Set(
+    collectMatches(
+      content,
+      /querySelector(All)?(?:<[^>]*>)?\(\s*['"`]([^'"`]+)['"`]\s*\)/,
+      (match) => match[2]
+    )
+  );
+
+  const domOperations = new Set();
+  domOperationPatterns.forEach(({ label, regex }) => {
+    if (regex.test(content)) {
+      domOperations.add(label);
+    }
+  });
+
+  return {
+    windowGlobals,
+    domIds,
+    domIdTemplates,
+    selectors,
+    domOperations,
+  };
+};
+
+const mergeSets = (target, source) => {
+  source.forEach((value) => target.add(value));
+};
+
+const main = async () => {
+  const files = [];
+  try {
+    await fs.access(featuresDir);
+    await walkDir(featuresDir, files);
+  } catch {
+    // ignore missing features directory
+  }
+
+  try {
+    await fs.access(mainEntry);
+    files.push(mainEntry);
+  } catch {
+    // ignore missing main entry
+  }
+
+  const report = {};
+
+  for (const file of files) {
+    const content = await fs.readFile(file, "utf8");
+    const summary = summarizeFile(content);
+    const featureName = getFeatureName(file);
+
+    if (!report[featureName]) {
+      report[featureName] = {
+        files: [],
+        windowGlobals: new Set(),
+        domIds: new Set(),
+        domIdTemplates: new Set(),
+        selectors: new Set(),
+        domOperations: new Set(),
+      };
+    }
+
+    report[featureName].files.push(path.relative(rootDir, file));
+    mergeSets(report[featureName].windowGlobals, summary.windowGlobals);
+    mergeSets(report[featureName].domIds, summary.domIds);
+    mergeSets(report[featureName].domIdTemplates, summary.domIdTemplates);
+    mergeSets(report[featureName].selectors, summary.selectors);
+    mergeSets(report[featureName].domOperations, summary.domOperations);
+  }
+
+  const output = Object.fromEntries(
+    Object.entries(report).map(([feature, data]) => [
+      feature,
+      {
+        files: data.files.sort(),
+        windowGlobals: Array.from(data.windowGlobals).sort(),
+        domIds: Array.from(data.domIds).sort(),
+        domIdTemplates: Array.from(data.domIdTemplates).sort(),
+        selectors: Array.from(data.selectors).sort(),
+        domOperations: Array.from(data.domOperations).sort(),
+      },
+    ])
+  );
+
+  const outputPath = path.join(rootDir, "legacy-deps-report.json");
+  await fs.writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+  console.log(`Legacy dependency report written to ${path.relative(rootDir, outputPath)}`);
+};
+
+await main();

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -10,6 +10,12 @@ import {
   saveCharacterData,
   useCharacter,
 } from "../features/character";
+import { useCharacterCalculations } from "../features/character/hooks/useCharacterCalculations";
+import AttributesSection from "../features/character/components/AttributesSection";
+import CombatBaseSection from "../features/character/components/CombatBaseSection";
+import HiddenAttributesSection from "../features/character/components/HiddenAttributesSection";
+import ModifiersSection from "../features/character/components/ModifiersSection";
+import SonderwerteSection from "../features/character/components/SonderwerteSection";
 import VanillaMagicSystem from "../features/magic/VanillaMagicSystem";
 import type { MagicSystemState } from "../features/magic/types";
 
@@ -47,6 +53,48 @@ type TabsProps = {
 const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange }: TabsProps) => {
   const [activeTab, setActiveTab] = useState<TabKey>("charakter");
   const { name, experience, setLevel, setXp, setSteigerungspunkte } = useCharacter();
+  const magicSum = magicState.magicAbilities.reduce((sum, ability) => sum + (ability.level ?? 0), 0);
+  const { attributes, setAttributes, modifiers, setModifiers, derived } = useCharacterCalculations(magicSum);
+  const [hiddenAttributes, setHiddenAttributes] = useState<Array<keyof typeof attributes>>([]);
+
+  const attributeMin = 7;
+  const attributeMax = Math.min(derived.level + 12, 21);
+  const modifierMin = 0;
+  const modifierMax = derived.level + 2;
+
+  const handleAttributeChange = (key: keyof typeof attributes, value: number) => {
+    setAttributes((current) => ({ ...current, [key]: value }));
+  };
+
+  const handleModifierChange = (key: keyof typeof modifiers, value: number) => {
+    setModifiers((current) => ({ ...current, [key]: value }));
+  };
+
+  const handleHideAttribute = (key: keyof typeof attributes) => {
+    setHiddenAttributes((current) => (current.includes(key) ? current : [...current, key]));
+  };
+
+  const handleRestoreAttribute = (key: keyof typeof attributes) => {
+    setHiddenAttributes((current) => current.filter((item) => item !== key));
+  };
+
+  const setAllAttributeValues = (value: number) => {
+    setAttributes((current) =>
+      (Object.keys(current) as Array<keyof typeof current>).reduce(
+        (acc, key) => ({ ...acc, [key]: value }),
+        { ...current }
+      )
+    );
+  };
+
+  const setAllModifierValues = (value: number) => {
+    setModifiers((current) =>
+      (Object.keys(current) as Array<keyof typeof current>).reduce(
+        (acc, key) => ({ ...acc, [key]: value }),
+        { ...current }
+      )
+    );
+  };
 
   return (
     <div className="tabs-container">
@@ -192,271 +240,25 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
             </div>
 
             <div className="three-column-container">
-              <div className="FlexItemContainer" id="kampfBasisContainer">
-                <h6>Kampf Basiswerte</h6>
-                <div className="FlexItem">
-                  <label>Wurfwaffen Basiswert:</label>
-                  <input
-                    className="stg attributeInput KampfBasiswerte"
-                    type="number"
-                    defaultValue={0}
-                    id="KampfBasiswerte_Wurfwaffen_Basiswert"
-                  />
-                  <span className="readonly-value">×</span>
-                </div>
-                <div className="FlexItem">
-                  <label>Schusswaffen Basiswert:</label>
-                  <input
-                    className="stg attributeInput KampfBasiswerte"
-                    type="number"
-                    defaultValue={0}
-                    id="KampfBasiswerte_Schusswaffen_Basiswert"
-                  />
-                  <span className="readonly-value">×</span>
-                </div>
-                <div className="FlexItem">
-                  <label>Attacke Basiswert:</label>
-                  <input
-                    className="stg attributeInput KampfBasiswerte"
-                    type="number"
-                    defaultValue={0}
-                    id="KampfBasiswerte_Attacke_Basiswert"
-                  />
-                  <span className="readonly-value">×</span>
-                </div>
-                <div className="FlexItem">
-                  <label>Parade Basiswert:</label>
-                  <input
-                    className="stg attributeInput KampfBasiswerte"
-                    type="number"
-                    defaultValue={0}
-                    id="KampfBasiswerte_Parade_Basiswert"
-                  />
-                  <span className="readonly-value">×</span>
-                </div>
-              </div>
-
-              <div className="FlexItemContainer" id="modifierContainer">
-                <h6>Modifier</h6>
-                <div className="modifier-flex">
-                  <div className="FlexItem">
-                    <label>Magie:</label>
-                    <input className="stg attributeInput modifier" type="number" defaultValue={0} id="modifier_magie" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>ASP:</label>
-                    <input className="stg attributeInput modifier" type="number" defaultValue={0} id="modifier_asp" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>LP:</label>
-                    <input className="stg attributeInput modifier" type="number" defaultValue={0} id="modifier_lp" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Fernkampf:</label>
-                    <input
-                      className="stg attributeInput modifier"
-                      type="number"
-                      defaultValue={0}
-                      id="modifier_fernkampf"
-                    />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Nahkampf:</label>
-                    <input
-                      className="stg attributeInput modifier"
-                      type="number"
-                      defaultValue={0}
-                      id="modifier_nahkampf"
-                    />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Gift:</label>
-                    <input className="stg attributeInput modifier" type="number" defaultValue={0} id="modifier_gift" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Stealth:</label>
-                    <input
-                      className="stg attributeInput modifier"
-                      type="number"
-                      defaultValue={0}
-                      id="modifier_stealth"
-                    />
-                    <span className="readonly-value">×</span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="FlexItemContainer" id="attributeContainer">
-                <h6>Attribute</h6>
-                <div className="attribute-flex">
-                  <div className="FlexItem">
-                    <label>Konstitution:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Konstitution" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Körperkraft:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Körperkraft" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Gewandheit:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Gewandheit" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Klugheit:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Klugheit" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Intuition:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Intuition" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Geschicklichkeit:</label>
-                    <input
-                      className="stg attributeInput attribute"
-                      type="number"
-                      defaultValue={9}
-                      id="attribute_Geschicklichkeit"
-                    />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Tarnung:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Tarnung" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Fingerfertigkeit:</label>
-                    <input
-                      className="stg attributeInput attribute"
-                      type="number"
-                      defaultValue={9}
-                      id="attribute_Fingerfertigkeit"
-                    />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Sinnesschärfe:</label>
-                    <input
-                      className="stg attributeInput attribute"
-                      type="number"
-                      defaultValue={9}
-                      id="attribute_Sinnesschärfe"
-                    />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Charisma:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Charisma" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Willenskraft:</label>
-                    <input className="stg attributeInput attribute" type="number" defaultValue={9} id="attribute_Willenskraft" />
-                    <button type="button" className="hidebutton">
-                      X
-                    </button>
-                  </div>
-                </div>
-              </div>
+              <CombatBaseSection derived={derived} />
+              <ModifiersSection
+                modifiers={modifiers}
+                onChange={handleModifierChange}
+                minValue={modifierMin}
+                maxValue={modifierMax}
+              />
+              <AttributesSection
+                attributes={attributes}
+                onChange={handleAttributeChange}
+                minValue={attributeMin}
+                maxValue={attributeMax}
+                hiddenKeys={hiddenAttributes}
+                onHide={handleHideAttribute}
+              />
             </div>
 
             <div className="three-column-container">
-              <div className="FlexItemContainer" id="sonderwerteContainer">
-                <h6>Sonderwerte</h6>
-                <div className="sonderwerte-flex">
-                  <div className="FlexItem">
-                    <label>Aktuelle LP:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Aktuelle_LP" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Maximale LP:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Maximale_LP" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Ausdauer:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Ausdauer" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Maximale Ausdauer:</label>
-                    <input
-                      className="stg attributeInput sonderwerte"
-                      type="number"
-                      defaultValue={0}
-                      id="sonderwerte_Maximale_Ausdauer"
-                    />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Astralenergie:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Astralenergie" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Maximale Astralenergie:</label>
-                    <input
-                      className="stg attributeInput sonderwerte"
-                      type="number"
-                      defaultValue={0}
-                      id="sonderwerte_Maximale_Astralenergie"
-                    />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Magiebegabung:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Magiebegabung" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Magieresistenz:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Magieresistenz" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Giftresistenz:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Giftresistenz" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                  <div className="FlexItem">
-                    <label>Schnelligkeit:</label>
-                    <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Schnelligkeit" />
-                    <span className="readonly-value">×</span>
-                  </div>
-                </div>
-              </div>
+              <SonderwerteSection derived={derived} />
             </div>
 
             <div className="FlexItemContainer BigFlexItemContainer" id="kampfTalenteContainer">
@@ -477,7 +279,16 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
             id="hiddenItemsContainer"
             className="hidden-items"
             style={{ display: hiddenItemsVisible ? "flex" : "none" }}
-          ></div>
+          >
+            <HiddenAttributesSection
+              attributes={attributes}
+              hiddenKeys={hiddenAttributes}
+              minValue={attributeMin}
+              maxValue={attributeMax}
+              onChange={handleAttributeChange}
+              onRestore={handleRestoreAttribute}
+            />
+          </div>
         </div>
 
         <div className={`tab-content${activeTab === "inventar" ? " active" : ""}`} id="inventar-tab">
@@ -600,10 +411,24 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
         <div className={`tab-content${activeTab === "einstellungen" ? " active" : ""}`} id="einstellungen-tab">
           <div className="FlexItemContainer">
             <h6>Charakter Einstellungen</h6>
-            <button type="button" id="setMin">
+            <button
+              type="button"
+              id="setMin"
+              onClick={() => {
+                setAllAttributeValues(attributeMin);
+                setAllModifierValues(modifierMin);
+              }}
+            >
               Alle Werte auf Minimum setzen
             </button>
-            <button type="button" id="setMax">
+            <button
+              type="button"
+              id="setMax"
+              onClick={() => {
+                setAllAttributeValues(attributeMax);
+                setAllModifierValues(modifierMax);
+              }}
+            >
               Alle Werte auf Maximum setzen
             </button>
           </div>

--- a/src/features/character/components/AttributesSection.tsx
+++ b/src/features/character/components/AttributesSection.tsx
@@ -1,0 +1,86 @@
+import type { ChangeEvent } from "react";
+import type { CoreAttributes } from "../services/derivedCalculations";
+
+type AttributesSectionProps = {
+  attributes: CoreAttributes;
+  onChange: (key: keyof CoreAttributes, value: number) => void;
+  minValue: number;
+  maxValue: number;
+  hiddenKeys?: Array<keyof CoreAttributes>;
+  onHide?: (key: keyof CoreAttributes) => void;
+};
+
+const labelMap: Record<keyof CoreAttributes, string> = {
+  konstitution: "Konstitution",
+  körperkraft: "Körperkraft",
+  gewandheit: "Gewandheit",
+  klugheit: "Klugheit",
+  intuition: "Intuition",
+  fingerfertigkeit: "Fingerfertigkeit",
+  charisma: "Charisma",
+  geschicklichkeit: "Geschicklichkeit",
+  tarnung: "Tarnung",
+  sinnesschärfe: "Sinnesschärfe",
+  willenskraft: "Willenskraft",
+};
+
+const idMap: Record<keyof CoreAttributes, string> = {
+  konstitution: "attribute_Konstitution",
+  körperkraft: "attribute_Körperkraft",
+  gewandheit: "attribute_Gewandheit",
+  klugheit: "attribute_Klugheit",
+  intuition: "attribute_Intuition",
+  fingerfertigkeit: "attribute_Fingerfertigkeit",
+  charisma: "attribute_Charisma",
+  geschicklichkeit: "attribute_Geschicklichkeit",
+  tarnung: "attribute_Tarnung",
+  sinnesschärfe: "attribute_Sinnesschärfe",
+  willenskraft: "attribute_Willenskraft",
+};
+
+const AttributesSection = ({
+  attributes,
+  onChange,
+  minValue,
+  maxValue,
+  hiddenKeys = [],
+  onHide,
+}: AttributesSectionProps) => {
+  const handleChange =
+    (key: keyof CoreAttributes) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = Number.parseInt(event.target.value, 10) || 0;
+      onChange(key, value);
+    };
+
+  const visibleKeys = (Object.keys(attributes) as Array<keyof CoreAttributes>).filter(
+    (key) => !hiddenKeys.includes(key)
+  );
+
+  return (
+    <div className="FlexItemContainer" id="attributeContainer">
+      <h6>Attribute</h6>
+      <div className="attribute-flex">
+        {visibleKeys.map((key) => (
+          <div className="FlexItem" key={key}>
+            <label>{labelMap[key]}:</label>
+            <input
+              className="stg attributeInput attribute"
+              type="number"
+              value={attributes[key]}
+              min={minValue}
+              max={maxValue}
+              onChange={handleChange(key)}
+              id={idMap[key]}
+            />
+            <button type="button" className="hidebutton" onClick={() => onHide?.(key)}>
+              X
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AttributesSection;

--- a/src/features/character/components/CombatBaseSection.tsx
+++ b/src/features/character/components/CombatBaseSection.tsx
@@ -1,0 +1,57 @@
+import type { DerivedValues } from "../services/derivedCalculations";
+
+type CombatBaseSectionProps = {
+  derived: DerivedValues;
+};
+
+const CombatBaseSection = ({ derived }: CombatBaseSectionProps) => (
+  <div className="FlexItemContainer" id="kampfBasisContainer">
+    <h6>Kampf Basiswerte</h6>
+    <div className="FlexItem">
+      <label>Wurfwaffen Basiswert:</label>
+      <input
+        className="stg attributeInput KampfBasiswerte"
+        type="number"
+        value={derived.wurf}
+        readOnly
+        id="KampfBasiswerte_Wurfwaffen_Basiswert"
+      />
+      <span className="readonly-value">×</span>
+    </div>
+    <div className="FlexItem">
+      <label>Schusswaffen Basiswert:</label>
+      <input
+        className="stg attributeInput KampfBasiswerte"
+        type="number"
+        value={derived.schuss}
+        readOnly
+        id="KampfBasiswerte_Schusswaffen_Basiswert"
+      />
+      <span className="readonly-value">×</span>
+    </div>
+    <div className="FlexItem">
+      <label>Attacke Basiswert:</label>
+      <input
+        className="stg attributeInput KampfBasiswerte"
+        type="number"
+        value={derived.attacke}
+        readOnly
+        id="KampfBasiswerte_Attacke_Basiswert"
+      />
+      <span className="readonly-value">×</span>
+    </div>
+    <div className="FlexItem">
+      <label>Parade Basiswert:</label>
+      <input
+        className="stg attributeInput KampfBasiswerte"
+        type="number"
+        value={derived.parade}
+        readOnly
+        id="KampfBasiswerte_Parade_Basiswert"
+      />
+      <span className="readonly-value">×</span>
+    </div>
+  </div>
+);
+
+export default CombatBaseSection;

--- a/src/features/character/components/HiddenAttributesSection.tsx
+++ b/src/features/character/components/HiddenAttributesSection.tsx
@@ -1,0 +1,83 @@
+import type { ChangeEvent } from "react";
+import type { CoreAttributes } from "../services/derivedCalculations";
+
+type HiddenAttributesSectionProps = {
+  attributes: CoreAttributes;
+  hiddenKeys: Array<keyof CoreAttributes>;
+  minValue: number;
+  maxValue: number;
+  onChange: (key: keyof CoreAttributes, value: number) => void;
+  onRestore: (key: keyof CoreAttributes) => void;
+};
+
+const labelMap: Record<keyof CoreAttributes, string> = {
+  konstitution: "Konstitution",
+  körperkraft: "Körperkraft",
+  gewandheit: "Gewandheit",
+  klugheit: "Klugheit",
+  intuition: "Intuition",
+  fingerfertigkeit: "Fingerfertigkeit",
+  charisma: "Charisma",
+  geschicklichkeit: "Geschicklichkeit",
+  tarnung: "Tarnung",
+  sinnesschärfe: "Sinnesschärfe",
+  willenskraft: "Willenskraft",
+};
+
+const idMap: Record<keyof CoreAttributes, string> = {
+  konstitution: "attribute_Konstitution",
+  körperkraft: "attribute_Körperkraft",
+  gewandheit: "attribute_Gewandheit",
+  klugheit: "attribute_Klugheit",
+  intuition: "attribute_Intuition",
+  fingerfertigkeit: "attribute_Fingerfertigkeit",
+  charisma: "attribute_Charisma",
+  geschicklichkeit: "attribute_Geschicklichkeit",
+  tarnung: "attribute_Tarnung",
+  sinnesschärfe: "attribute_Sinnesschärfe",
+  willenskraft: "attribute_Willenskraft",
+};
+
+const HiddenAttributesSection = ({
+  attributes,
+  hiddenKeys,
+  minValue,
+  maxValue,
+  onChange,
+  onRestore,
+}: HiddenAttributesSectionProps) => {
+  if (hiddenKeys.length === 0) {
+    return <p>Keine ausgeblendeten Attribute.</p>;
+  }
+
+  const handleChange =
+    (key: keyof CoreAttributes) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = Number.parseInt(event.target.value, 10) || 0;
+      onChange(key, value);
+    };
+
+  return (
+    <div className="hidden-attributes">
+      {hiddenKeys.map((key) => (
+        <div className="FlexItem" key={key}>
+          <label>{labelMap[key]}:</label>
+          <input
+            className="stg attributeInput attribute"
+            type="number"
+            value={attributes[key]}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange(key)}
+            id={idMap[key]}
+          />
+          <button type="button" className="hidebutton" onClick={() => onRestore(key)}>
+            {"<"}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HiddenAttributesSection;

--- a/src/features/character/components/ModifiersSection.tsx
+++ b/src/features/character/components/ModifiersSection.tsx
@@ -1,0 +1,119 @@
+import type { ChangeEvent } from "react";
+import type { CoreModifiers } from "../services/derivedCalculations";
+
+type ModifiersSectionProps = {
+  modifiers: CoreModifiers;
+  onChange: (key: keyof CoreModifiers, value: number) => void;
+  minValue: number;
+  maxValue: number;
+};
+
+const ModifiersSection = ({ modifiers, onChange, minValue, maxValue }: ModifiersSectionProps) => {
+  const handleChange =
+    (key: keyof CoreModifiers) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = Number.parseInt(event.target.value, 10) || 0;
+      onChange(key, value);
+    };
+
+  return (
+    <div className="FlexItemContainer" id="modifierContainer">
+      <h6>Modifier</h6>
+      <div className="modifier-flex">
+        <div className="FlexItem">
+          <label>Magie:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.magie}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("magie")}
+            id="modifier_magie"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>ASP:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.asp}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("asp")}
+            id="modifier_asp"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>LP:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.lp}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("lp")}
+            id="modifier_lp"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>Fernkampf:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.fernkampf}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("fernkampf")}
+            id="modifier_fernkampf"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>Nahkampf:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.nahkampf}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("nahkampf")}
+            id="modifier_nahkampf"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>Gift:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.gift}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("gift")}
+            id="modifier_gift"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+        <div className="FlexItem">
+          <label>Stealth:</label>
+          <input
+            className="stg attributeInput modifier"
+            type="number"
+            value={modifiers.stealth}
+            min={minValue}
+            max={maxValue}
+            onChange={handleChange("stealth")}
+            id="modifier_stealth"
+          />
+          <span className="readonly-value">×</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ModifiersSection;

--- a/src/features/character/components/SonderwerteSection.tsx
+++ b/src/features/character/components/SonderwerteSection.tsx
@@ -1,0 +1,107 @@
+import type { DerivedValues } from "../services/derivedCalculations";
+
+type SonderwerteSectionProps = {
+  derived: DerivedValues;
+};
+
+const SonderwerteSection = ({ derived }: SonderwerteSectionProps) => (
+  <div className="FlexItemContainer" id="sonderwerteContainer">
+    <h6>Sonderwerte</h6>
+    <div className="sonderwerte-flex">
+      <div className="FlexItem">
+        <label>Aktuelle LP:</label>
+        <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Aktuelle_LP" />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Maximale LP:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.lpMax}
+          readOnly
+          id="sonderwerte_Maximale_LP"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Ausdauer:</label>
+        <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Ausdauer" />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Maximale Ausdauer:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.ausdauerMax}
+          readOnly
+          id="sonderwerte_Maximale_Ausdauer"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Astralenergie:</label>
+        <input className="stg attributeInput sonderwerte" type="number" defaultValue={0} id="sonderwerte_Astralenergie" />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Maximale Astralenergie:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.maxAstralenergie}
+          readOnly
+          id="sonderwerte_Maximale_Astralenergie"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Magiebegabung:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.magiebegabung}
+          readOnly
+          id="sonderwerte_Magiebegabung"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Magieresistenz:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.magieresistenz}
+          readOnly
+          id="sonderwerte_Magieresistenz"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Giftresistenz:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.giftresistenz}
+          readOnly
+          id="sonderwerte_Giftresistenz"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+      <div className="FlexItem">
+        <label>Schnelligkeit:</label>
+        <input
+          className="stg attributeInput sonderwerte"
+          type="number"
+          value={derived.schnelligkeit}
+          readOnly
+          id="sonderwerte_Schnelligkeit"
+        />
+        <span className="readonly-value">×</span>
+      </div>
+    </div>
+  </div>
+);
+
+export default SonderwerteSection;

--- a/src/features/character/hooks/useCharacterCalculations.ts
+++ b/src/features/character/hooks/useCharacterCalculations.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from "react";
+import { useCharacter } from "../CharacterContext";
+import {
+  calculateDerivedValues,
+  calculateLevelFromXp,
+  type CoreAttributes,
+  type CoreModifiers,
+} from "../services/derivedCalculations";
+
+const defaultAttributes: CoreAttributes = {
+  konstitution: 9,
+  körperkraft: 9,
+  gewandheit: 9,
+  klugheit: 9,
+  intuition: 9,
+  fingerfertigkeit: 9,
+  charisma: 9,
+  geschicklichkeit: 9,
+  tarnung: 9,
+  sinnesschärfe: 9,
+  willenskraft: 9,
+};
+
+const defaultModifiers: CoreModifiers = {
+  lp: 0,
+  asp: 0,
+  magie: 0,
+  fernkampf: 0,
+  nahkampf: 0,
+  gift: 0,
+  stealth: 0,
+};
+
+export const useCharacterCalculations = (magicSum: number) => {
+  const { experience, setLevel } = useCharacter();
+  const [attributes, setAttributes] = useState<CoreAttributes>(defaultAttributes);
+  const [modifiers, setModifiers] = useState<CoreModifiers>(defaultModifiers);
+
+  useEffect(() => {
+    const nextLevel = calculateLevelFromXp(experience.xp);
+    if (experience.level !== nextLevel) {
+      setLevel(nextLevel);
+    }
+  }, [experience.level, experience.xp, setLevel]);
+
+  const derived = useMemo(
+    () =>
+      calculateDerivedValues({
+        attributes,
+        modifiers,
+        experience,
+        magicSum,
+      }),
+    [attributes, modifiers, experience, magicSum]
+  );
+
+  return {
+    attributes,
+    setAttributes,
+    modifiers,
+    setModifiers,
+    derived,
+  };
+};

--- a/src/features/character/services/calculations.ts
+++ b/src/features/character/services/calculations.ts
@@ -1,6 +1,12 @@
 // calculations.js - Angepasst für das neue Magie-System
 import { readNumericInput, writeDerivedValue, writeInputValue } from "./characterState";
 import { applyMaxValueSettings } from "./maxValueSettings";
+import {
+  calculateDerivedValues,
+  calculateLevelFromXp,
+  type CoreAttributes,
+  type CoreModifiers,
+} from "./derivedCalculations";
 import type { MagicAbility } from "../../../types/character";
 
 const getInputElement = (id: string) => {
@@ -59,34 +65,59 @@ export function updateCharakterCalculation() {
   }
 
   try {
-    // Level-Berechnung
-    if (xp < 750) {
-      // Erste 6 Level, jeweils 150 XP
-      level = Math.floor(xp / 150) + 1;
-    } else if (xp < 4950) {
-      // Level 7 bis 13, jeweils 600 XP
-      level = Math.floor((xp - 750) / 600) + 7;
-    } else {
-      // Level 14 und höher, jeweils 1200 XP
-      level = Math.floor((xp - 4950) / 1200) + 14;
-    }
+    level = calculateLevelFromXp(xp);
 
     // Setze den Level
     writeInputValue("erfahrung_level", level);
 
-    // Berechnungen der Werte
-    LP = lpModifier * 3 + level * 6 + 20 + KO;
-    AUSD = LP + WIL;
-    MB = totalSum + magicModifier;  // Hier wird die Magiesumme verwendet
-    maxASP = level * 6 + aspModifier * 2 + MB;
-    MR = Math.round((MB + level + KL) / 3);
-    Giftresistenz = Math.round((AUSD) / 10 + giftModifier);
-    wurf = Math.round((IN + FF + KK) / 4);
-    schuss = Math.round((IN + FF + KK) / 4);
-    Attacke = Math.round((KO + GE + KK) / 5);
-    Parade = Math.round((IN + GE + KK) / 5);
+    const attributes: CoreAttributes = {
+      konstitution: KO,
+      körperkraft: KK,
+      gewandheit: GE,
+      klugheit: KL,
+      intuition: IN,
+      fingerfertigkeit: FF,
+      charisma: CH,
+      geschicklichkeit: GESCH,
+      tarnung: Tarnung,
+      sinnesschärfe: Sin,
+      willenskraft: WIL,
+    };
+
+    const modifiers: CoreModifiers = {
+      lp: lpModifier,
+      asp: aspModifier,
+      magie: magicModifier,
+      fernkampf: fernModifier,
+      nahkampf: nahModifier,
+      gift: giftModifier,
+      stealth: 0,
+    };
+
+    const derived = calculateDerivedValues({
+      attributes,
+      modifiers,
+      experience: {
+        xp,
+        level,
+        steigerungspunkte: 0,
+        gesteigerte: Gesteigerte,
+      },
+      magicSum: totalSum,
+    });
+
+    LP = derived.lpMax;
+    AUSD = derived.ausdauerMax;
+    MB = derived.magiebegabung;
+    maxASP = derived.maxAstralenergie;
+    MR = derived.magieresistenz;
+    Giftresistenz = derived.giftresistenz;
+    wurf = derived.wurf;
+    schuss = derived.schuss;
+    Attacke = derived.attacke;
+    Parade = derived.parade;
     Steigerungspunkte = level * 30 + 100 - Gesteigerte;
-    Schnelligkeit = Math.round((KK + GE + Sin) / 4)
+    Schnelligkeit = derived.schnelligkeit;
 
     // Setze die berechneten Werte
     writeDerivedValue("sonderwerte_Maximale_LP", LP);

--- a/src/features/character/services/derivedCalculations.ts
+++ b/src/features/character/services/derivedCalculations.ts
@@ -1,0 +1,92 @@
+export type CoreAttributes = {
+  konstitution: number;
+  körperkraft: number;
+  gewandheit: number;
+  klugheit: number;
+  intuition: number;
+  fingerfertigkeit: number;
+  charisma: number;
+  geschicklichkeit: number;
+  tarnung: number;
+  sinnesschärfe: number;
+  willenskraft: number;
+};
+
+export type CoreModifiers = {
+  lp: number;
+  asp: number;
+  magie: number;
+  fernkampf: number;
+  nahkampf: number;
+  gift: number;
+  stealth: number;
+};
+
+export type ExperienceSnapshot = {
+  xp: number;
+  level: number;
+  steigerungspunkte: number;
+  gesteigerte: number;
+};
+
+export type DerivedValues = {
+  level: number;
+  lpMax: number;
+  ausdauerMax: number;
+  magiebegabung: number;
+  maxAstralenergie: number;
+  magieresistenz: number;
+  giftresistenz: number;
+  wurf: number;
+  schuss: number;
+  attacke: number;
+  parade: number;
+  schnelligkeit: number;
+};
+
+export const calculateLevelFromXp = (xp: number) => {
+  if (xp < 750) {
+    return Math.floor(xp / 150) + 1;
+  }
+  if (xp < 4950) {
+    return Math.floor((xp - 750) / 600) + 7;
+  }
+  return Math.floor((xp - 4950) / 1200) + 14;
+};
+
+type DerivedInputs = {
+  attributes: CoreAttributes;
+  modifiers: CoreModifiers;
+  experience: ExperienceSnapshot;
+  magicSum: number;
+};
+
+export const calculateDerivedValues = ({ attributes, modifiers, experience, magicSum }: DerivedInputs): DerivedValues => {
+  const level = experience.level || calculateLevelFromXp(experience.xp);
+  const lpMax = modifiers.lp * 3 + level * 6 + 20 + attributes.konstitution;
+  const ausdauerMax = lpMax + attributes.willenskraft;
+  const magiebegabung = magicSum + modifiers.magie;
+  const maxAstralenergie = level * 6 + modifiers.asp * 2 + magiebegabung;
+  const magieresistenz = Math.round((magiebegabung + level + attributes.klugheit) / 3);
+  const giftresistenz = Math.round(ausdauerMax / 10 + modifiers.gift);
+  const wurf = Math.round((attributes.intuition + attributes.fingerfertigkeit + attributes.körperkraft) / 4);
+  const schuss = Math.round((attributes.intuition + attributes.fingerfertigkeit + attributes.körperkraft) / 4);
+  const attacke = Math.round((attributes.konstitution + attributes.gewandheit + attributes.körperkraft) / 5);
+  const parade = Math.round((attributes.intuition + attributes.gewandheit + attributes.körperkraft) / 5);
+  const schnelligkeit = Math.round((attributes.körperkraft + attributes.gewandheit + attributes.sinnesschärfe) / 4);
+
+  return {
+    level,
+    lpMax,
+    ausdauerMax,
+    magiebegabung,
+    maxAstralenergie,
+    magieresistenz,
+    giftresistenz,
+    wurf,
+    schuss,
+    attacke,
+    parade,
+    schnelligkeit,
+  };
+};


### PR DESCRIPTION
### Motivation
- Continue the component migration by moving visibility (hide/restore) and min/max value logic for attributes/modifiers from legacy DOM manipulation into React state so behavior is easier to reason about and componentise. 
- Provide a UI view for hidden attributes in the "Ausgeblendete" tab and expose calculated min/max constraints from React state.

### Description
- Added React components `AttributesSection`, `ModifiersSection`, `CombatBaseSection`, `SonderwerteSection`, and `HiddenAttributesSection` under `src/features/character/components/` and wired them into `src/components/Tabs.tsx` so attribute hide/restore and readonly derived fields render from state. 
- Introduced the `useCharacterCalculations` hook in `src/features/character/hooks/useCharacterCalculations.ts` to manage `attributes`/`modifiers` state and compute derived values via the new pure helpers in `src/features/character/services/derivedCalculations.ts`.
- Updated `src/features/character/services/calculations.ts` to reuse `calculateLevelFromXp`/`calculateDerivedValues` for legacy DOM-driven flows so both React and legacy code share the same logic. 
- Added a reproducible inventory script `scripts/legacy-deps-inventory.mjs`, committed the generated `legacy-deps-report.json`, and updated `DATEI_DOKUMENTATION.md` to reflect the new components and migration progress, plus wired min/max buttons and bulk-set actions into `Tabs.tsx`.

### Testing
- Ran the inventory script with `node scripts/legacy-deps-inventory.mjs`, which completed successfully and wrote `legacy-deps-report.json` (succeeded). 
- No unit tests, typecheck, lint, formatter or build were executed as part of this change (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5f981fec832ca0c4c80d69c0c960)