### PR TITLE
Refactor Tabs to use exported service functions instead of window globals

### DIFF
--- a/DATEI_DOKUMENTATION.md
+++ b/DATEI_DOKUMENTATION.md
@@ -205,12 +205,12 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 - Erste React-State-Berechnungen für Kernattribute/Modifier inkl. abgeleiteter Basis-/Sonderwerte umgesetzt (Codex-Aufgabe 2 gestartet).
 - UI-Abschnitte für Attribute/Modifier/Sonderwerte/Kampf-Basiswerte in React-Komponenten ausgelagert (Codex-Aufgabe 3 gestartet).
 - Hide-Buttons/Min-Max-Aktionen für Attribute/Modifier nach React-State überführt (Codex-Aufgabe 4 gestartet).
+- Tabs rufen Legacy-Services direkt auf, statt globale `window`-Funktionen zu nutzen (Codex-Aufgabe 5 umgesetzt).
 
 ### Was noch zu migrieren ist (weil aktuell noch Legacy-Skripte benötigt werden)
 
 - **DOM-Logik in `services/` → React-State/Komponenten:** Charakterberechnungen, Listener, Tabs, Wallet und Shop hängen noch direkt am DOM.
 - **UI-Abschnitte mit Legacy-IDs:** Attribute/Modifier/Sonderwerte/Kampf-Basiswerte sind als React-Komponenten gerendert; weitere Bereiche (Talente, Shop, Inventar) hängen noch an Legacy-IDs und müssen migriert werden.
-- **Global-Funktionen auf `window`:** Tabs rufen Legacy-Funktionen wie `Roll`, `TheChoosenOne`, `updateCharakterCalculation` usw. auf. Das sollte in lokale Hooks/Services umgebaut werden.
 - **Datei-Import/Export an React binden:** Save/Load ist bereits ausgelagert, aber die UI ist noch Teil des großen Tab-Markups; eine saubere Trennung in eigenständige Komponenten fehlt.
 - **Restliche Charakterberechnungen migrieren:** Talente/Gesteigerte-Logik, Auto-Skill-Verteilung und Listener/MaxValue-Logik außerhalb der Attribute/Modifier sind noch Legacy-basiert.
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -16,8 +16,14 @@ import CombatBaseSection from "../features/character/components/CombatBaseSectio
 import HiddenAttributesSection from "../features/character/components/HiddenAttributesSection";
 import ModifiersSection from "../features/character/components/ModifiersSection";
 import SonderwerteSection from "../features/character/components/SonderwerteSection";
+import { updateCharakterCalculation } from "../features/character/services/calculations";
+import { changeColor, changeFont } from "../features/character/services/skin";
+import { Roll, DiceChooser } from "../features/dice/services/dice";
+import { calculate, clearEqField, InToHTML } from "../features/dice/services/rechner";
 import VanillaMagicSystem from "../features/magic/VanillaMagicSystem";
 import type { MagicSystemState } from "../features/magic/types";
+import { addToInventoryFromInput, removeFromInventoryFromInput } from "../features/shop/services/shop";
+import { TheChoosenOne, wConvert, wReset } from "../features/shop/services/wallet";
 
 type TabKey = "charakter" | "magie" | "ausgeblendete" | "inventar" | "werkzeuge" | "einstellungen";
 
@@ -36,13 +42,6 @@ const tabs: TabDefinition[] = [
   { key: "einstellungen", label: "Einstellungen", contentId: "einstellungen-tab" },
 ];
 
-const invokeLegacy = (name: string, ...args: unknown[]) => {
-  const legacyFn = (window as typeof window & Record<string, (...params: unknown[]) => void>)[name];
-  if (typeof legacyFn === "function") {
-    legacyFn(...args);
-  }
-};
-
 type TabsProps = {
   listenersEnabled: boolean;
   hiddenItemsVisible: boolean;
@@ -56,6 +55,8 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
   const magicSum = magicState.magicAbilities.reduce((sum, ability) => sum + (ability.level ?? 0), 0);
   const { attributes, setAttributes, modifiers, setModifiers, derived } = useCharacterCalculations(magicSum);
   const [hiddenAttributes, setHiddenAttributes] = useState<Array<keyof typeof attributes>>([]);
+
+  // Tabs nutzt weiterhin diese DOM-basierten Services, bis die Features vollständig in React migriert sind.
 
   const attributeMin = 7;
   const attributeMax = Math.min(derived.level + 12, 21);
@@ -206,10 +207,10 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
                       Kreuzer
                     </option>
                   </select>
-                  <button type="submit" id="wadd" onClick={() => invokeLegacy("TheChoosenOne")}>
+                  <button type="submit" id="wadd" onClick={TheChoosenOne}>
                     Add Wallet
                   </button>
-                  <button type="submit" id="wconvert" onClick={() => invokeLegacy("wConvert")}>
+                  <button type="submit" id="wconvert" onClick={wConvert}>
                     Convert Wallet
                   </button>
 
@@ -227,16 +228,13 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
                       Kreuzer: <p id="showKreuzer"></p>
                     </div>
                   </div>
-                  <button type="submit" id="wReset" onClick={() => invokeLegacy("wReset")} style={{ marginTop: "20px" }}>
+                  <button type="submit" id="wReset" onClick={wReset} style={{ marginTop: "20px" }}>
                     Reset Wallet
                   </button>
                 </form>
               </div>
 
-              <ExperienceSection
-                onRecalculate={() => invokeLegacy("updateCharakterCalculation")}
-                listenersEnabled={listenersEnabled}
-              />
+              <ExperienceSection onRecalculate={updateCharakterCalculation} listenersEnabled={listenersEnabled} />
             </div>
 
             <div className="three-column-container">
@@ -303,10 +301,10 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
             <h6>Inventar</h6>
             <div>
               <input type="text" id="itemNameInput" placeholder="Artikelname" />
-              <button type="button" onClick={() => invokeLegacy("addToInventoryFromInput")}>
+              <button type="button" onClick={addToInventoryFromInput}>
                 Hinzufügen
               </button>
-              <button type="button" onClick={() => invokeLegacy("removeFromInventoryFromInput")}>
+              <button type="button" onClick={removeFromInventoryFromInput}>
                 Entfernen
               </button>
             </div>
@@ -318,7 +316,7 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
           <div className="FlexItemContainer">
             <h6>Würfelsystem</h6>
             <div className="dice-controls">
-              <select id="Dicer" defaultValue="d20" onChange={() => invokeLegacy("DiceChooser")}>
+              <select id="Dicer" defaultValue="d20" onChange={DiceChooser}>
                 <option value="d100">W100</option>
                 <option value="d20">W20</option>
                 <option value="d10">W10</option>
@@ -327,7 +325,7 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
               </select>
               <input type="number" id="DiceCount" defaultValue={1} min={1} max={20} />
               <input type="number" id="DiceSides" defaultValue={20} min={2} max={1000} className="disNone" />
-              <button type="button" onClick={() => invokeLegacy("Roll")}>
+              <button type="button" onClick={Roll}>
                 Würfeln
               </button>
             </div>
@@ -342,65 +340,65 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
                 <div id="evField" className="result-field"></div>
               </div>
               <div className="calculator-buttons">
-                <button type="button" onClick={() => invokeLegacy("clearEqField")} className="calc-button function-button">
+                <button type="button" onClick={clearEqField} className="calc-button function-button">
                   C
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "(")} className="calc-button function-button">
+                <button type="button" onClick={() => InToHTML("(")} className="calc-button function-button">
                   (
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", ")")} className="calc-button function-button">
+                <button type="button" onClick={() => InToHTML(")")} className="calc-button function-button">
                   )
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "/")} className="calc-button operator-button">
+                <button type="button" onClick={() => InToHTML("/")} className="calc-button operator-button">
                   /
                 </button>
 
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "7")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("7")} className="calc-button">
                   7
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "8")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("8")} className="calc-button">
                   8
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "9")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("9")} className="calc-button">
                   9
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "*")} className="calc-button operator-button">
+                <button type="button" onClick={() => InToHTML("*")} className="calc-button operator-button">
                   ×
                 </button>
 
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "4")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("4")} className="calc-button">
                   4
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "5")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("5")} className="calc-button">
                   5
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "6")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("6")} className="calc-button">
                   6
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "-")} className="calc-button operator-button">
+                <button type="button" onClick={() => InToHTML("-")} className="calc-button operator-button">
                   -
                 </button>
 
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "1")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("1")} className="calc-button">
                   1
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "2")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("2")} className="calc-button">
                   2
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "3")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("3")} className="calc-button">
                   3
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "+")} className="calc-button operator-button">
+                <button type="button" onClick={() => InToHTML("+")} className="calc-button operator-button">
                   +
                 </button>
 
-                <button type="button" onClick={() => invokeLegacy("InToHTML", "0")} className="calc-button">
+                <button type="button" onClick={() => InToHTML("0")} className="calc-button">
                   0
                 </button>
-                <button type="button" onClick={() => invokeLegacy("InToHTML", ".")} className="calc-button">
+                <button type="button" onClick={() => InToHTML(".")} className="calc-button">
                   .
                 </button>
-                <button type="button" onClick={() => invokeLegacy("calculate")} className="calc-button equal-button">
+                <button type="button" onClick={calculate} className="calc-button equal-button">
                   =
                 </button>
               </div>
@@ -437,14 +435,14 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
             <div>
               <label htmlFor="fontInput">Schriftart:</label>
               <input type="text" id="fontInput" placeholder="z.B. Arial, sans-serif" />
-              <button type="button" onClick={() => invokeLegacy("changeFont")}>
+              <button type="button" onClick={changeFont}>
                 Ändern
               </button>
             </div>
             <div>
               <label htmlFor="colorInput">Textfarbe:</label>
               <input type="color" id="colorInput" defaultValue="#36251b" />
-              <button type="button" onClick={() => invokeLegacy("changeColor")}>
+              <button type="button" onClick={changeColor}>
                 Ändern
               </button>
             </div>

--- a/src/features/character/services/skin.ts
+++ b/src/features/character/services/skin.ts
@@ -1,4 +1,4 @@
-function changeFont() {
+export function changeFont() {
     const fontInput = document.getElementById("fontInput");
     if (!(fontInput instanceof HTMLInputElement)) {
         return;
@@ -11,7 +11,7 @@ function changeFont() {
     }
 }
 
-function changeColor() {
+export function changeColor() {
     const colorInputElement = document.getElementById("colorInput");
     if (!(colorInputElement instanceof HTMLInputElement)) {
         return;
@@ -42,5 +42,3 @@ function changeColor() {
         alert("Bitte eine gültige Farbe eingeben.");
     }
 }
-
-export {};

--- a/src/features/dice/services/dice.ts
+++ b/src/features/dice/services/dice.ts
@@ -19,7 +19,7 @@ function toggleDiv() {
         div.style.display = "none";
     }
 }
-function Roll() {
+export function Roll() {
     const diceCountInput = getInputElement("DiceCount");
     const diceSidesInput = getInputElement("DiceSides");
     const showDice = getElement("showDice");
@@ -135,7 +135,7 @@ function createOctagon(result: number, DiceSide: number) {
     return svg;
 }
 
-function DiceChooser() {
+export function DiceChooser() {
     const Dicer = document.getElementById("Dicer");
     if (!(Dicer instanceof HTMLSelectElement)) {
         return;

--- a/src/features/dice/services/rechner.ts
+++ b/src/features/dice/services/rechner.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-function InToHTML(operation: string) {
+export function InToHTML(operation: string) {
     const eqField = document.getElementById("eqField");
     const evField = document.getElementById("evField");
     if (!eqField || !evField) {
@@ -10,7 +10,7 @@ function InToHTML(operation: string) {
     evField.innerText = " ";
 }
 
-function clearEqField() {
+export function clearEqField() {
     const eqField = document.getElementById("eqField");
     const evField = document.getElementById("evField");
     if (!eqField || !evField) {
@@ -20,7 +20,7 @@ function clearEqField() {
     evField.innerText = " ";
 }
 
-function calculate() {
+export function calculate() {
     const eqField = document.getElementById("eqField");
     const evField = document.getElementById("evField");
     if (!eqField || !evField) {
@@ -32,5 +32,3 @@ function calculate() {
     evField.innerText = String(result);
     console.log(calculation + "=" + result);
 }
-
-export {};

--- a/src/features/shop/services/shop.ts
+++ b/src/features/shop/services/shop.ts
@@ -63,7 +63,7 @@ function removeFromInventory(itemName: string, count = 1) {
 }
 
 // Funktionen für Benutzeraktionen im HTML
-function addToInventoryFromInput() {
+export function addToInventoryFromInput() {
     const itemInput = document.getElementById("itemNameInput");
     if (!(itemInput instanceof HTMLInputElement)) {
         return;
@@ -76,7 +76,7 @@ function addToInventoryFromInput() {
     }
 }
 
-function removeFromInventoryFromInput() {
+export function removeFromInventoryFromInput() {
     const itemInput = document.getElementById("itemNameInput");
     if (!(itemInput instanceof HTMLInputElement)) {
         return;

--- a/src/features/shop/services/wallet.ts
+++ b/src/features/shop/services/wallet.ts
@@ -31,7 +31,7 @@ export function updateWalletDisplay() {
     if (kreuzer) kreuzer.innerText = String(wallet.kreuzer);
 }
 
-function TheChoosenOne() {
+export function TheChoosenOne() {
     const CurrencyField = document.getElementById("CurrencyField");
     if (!(CurrencyField instanceof HTMLSelectElement)) {
         return;
@@ -61,7 +61,7 @@ function TheChoosenOne() {
     updateWalletDisplay();
 }
 
-function wConvert() {
+export function wConvert() {
     wallet.wInsg = wallet.kreuzer + wallet.heller * 10 + wallet.silber * 100 + wallet.dukaten * 1000;
 
     wallet.dukaten = Math.floor(wallet.wInsg / 1000);
@@ -79,7 +79,7 @@ function wConvert() {
     updateWalletDisplay();
 }
 
-function wReset() {
+export function wReset() {
     let wrReset = prompt("Bitte 'reset' eingeben, um dein Geld zurückzusetzen");
     if (wrReset === "reset") {
         wallet.wInsg = 0;


### PR DESCRIPTION
### Motivation
- Reduce reliance on global `window` functions from legacy scripts so `Tabs` can call typed service functions directly and simplify future React migration steps. 

### Description
- Replaced the `invokeLegacy` indirection in `src/components/Tabs.tsx` with direct imports and handlers from services (`calculate`, `clearEqField`, `InToHTML`, `Roll`, `DiceChooser`, `TheChoosenOne`, `wConvert`, `wReset`, `addToInventoryFromInput`, `removeFromInventoryFromInput`, `changeFont`, `changeColor`, `updateCharakterCalculation`).
- Exported previously internal functions in services so they can be used from the React UI: `export` added to `src/features/shop/services/shop.ts` (inventory helpers), `src/features/shop/services/wallet.ts` (wallet helpers), `src/features/dice/services/dice.ts` (dice functions), `src/features/dice/services/rechner.ts` (calculator functions), and `src/features/character/services/skin.ts` (layout helpers).
- Updated `DATEI_DOKUMENTATION.md` to mark Codex-Aufgabe 5 as implemented and removed the specific open item about Tabs calling `window` functions.
- Left a short explanatory comment in `Tabs.tsx` noting the temporary DOM-based services until a full React migration is completed.

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c93e2b2b8832c8104f2674fde5745)