### PR TITLE
Migrate shop & wallet to React context and components

### DIFF
--- a/DATEI_DOKUMENTATION.md
+++ b/DATEI_DOKUMENTATION.md
@@ -147,8 +147,18 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 
 ### Feature: Shop/Inventar
 
+- **src/features/shop/ShopContext.tsx**
+  - React-Context für Shop- und Wallet-State (Shopdaten, Käufe, Inventar).
+- **src/features/shop/store.ts**
+  - Kleiner Store für Shop-Snapshots (Wallet/Inventar), damit Save/Load ohne DOM funktioniert.
+- **src/features/shop/components/ShopPanel.tsx**
+  - React-Komponente für die Shop-Ansicht inkl. Kaufaktionen.
+- **src/features/shop/components/InventoryPanel.tsx**
+  - React-Komponente für Inventarverwaltung (Hinzufügen/Entfernen).
+- **src/features/shop/components/WalletPanel.tsx**
+  - React-Komponente für den Geldbeutel (Add/Convert/Reset).
 - **src/features/shop/index.ts**
-  - Index/Exports für Shop-Logik (Legacy-Anbindung).
+  - Index/Exports für Shop-Context und Shop-Store.
 - **src/features/shop/legacy.ts**
   - Lädt die DOM-basierten Shop-/Wallet-Services.
 - **src/features/shop/services/shop.ts**
@@ -206,10 +216,11 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 - UI-Abschnitte für Attribute/Modifier/Sonderwerte/Kampf-Basiswerte in React-Komponenten ausgelagert (Codex-Aufgabe 3 gestartet).
 - Hide-Buttons/Min-Max-Aktionen für Attribute/Modifier nach React-State überführt (Codex-Aufgabe 4 gestartet).
 - Tabs rufen Legacy-Services direkt auf, statt globale `window`-Funktionen zu nutzen (Codex-Aufgabe 5 umgesetzt).
+- Shop/Inventar-UI und Wallet-Logik in React-State migriert, inkl. Shop-Data-Loading (Codex-Aufgabe 6 umgesetzt).
 
 ### Was noch zu migrieren ist (weil aktuell noch Legacy-Skripte benötigt werden)
 
-- **DOM-Logik in `services/` → React-State/Komponenten:** Charakterberechnungen, Listener, Tabs, Wallet und Shop hängen noch direkt am DOM.
+- **DOM-Logik in `services/` → React-State/Komponenten:** Charakterberechnungen, Listener und Tabs hängen noch direkt am DOM.
 - **UI-Abschnitte mit Legacy-IDs:** Attribute/Modifier/Sonderwerte/Kampf-Basiswerte sind als React-Komponenten gerendert; weitere Bereiche (Talente, Shop, Inventar) hängen noch an Legacy-IDs und müssen migriert werden.
 - **Datei-Import/Export an React binden:** Save/Load ist bereits ausgelagert, aber die UI ist noch Teil des großen Tab-Markups; eine saubere Trennung in eigenständige Komponenten fehlt.
 - **Restliche Charakterberechnungen migrieren:** Talente/Gesteigerte-Logik, Auto-Skill-Verteilung und Listener/MaxValue-Logik außerhalb der Attribute/Modifier sind noch Legacy-basiert.
@@ -283,7 +294,7 @@ Da `src/main.tsx` weiterhin die Legacy-Skripte lädt und die Tabs `window`-Funkt
    - Baue die `window`-Funktionsaufrufe in `src/components/Tabs.tsx` auf lokale Handler/Hooks um.
    - Definiere klar, welche Funktionen/Services von Tabs benötigt werden.
 
-6) **Codex-Aufgabe: Shop & Wallet vollständig entkoppeln**
+6) **Codex-Aufgabe: Shop & Wallet vollständig entkoppeln (erledigt)**
    - Migriere die DOM-gebundene Shop-/Wallet-Logik (`src/features/shop/services/*`) in React-State.
    - Baue das Shop-/Inventar-UI als komponentenbasierte Ansicht mit sauberem Datenfluss.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import TopControls from "./components/TopControls";
 import Tabs from "./components/Tabs";
 import { CharacterProvider } from "./features/character";
+import { ShopProvider } from "./features/shop";
 import type { MagicSystemState } from "./features/magic/types";
 
 const App = () => {
@@ -21,21 +22,23 @@ const App = () => {
 
   return (
     <CharacterProvider>
-      <div className="app">
-        <TopControls
-          listenersEnabled={listenersEnabled}
-          onToggleListeners={setListenersEnabled}
-          hiddenItemsVisible={hiddenItemsVisible}
-          onToggleHiddenItems={setHiddenItemsVisible}
-          onAutoSkill={handleAutoSkill}
-        />
-        <Tabs
-          listenersEnabled={listenersEnabled}
-          hiddenItemsVisible={hiddenItemsVisible}
-          magicState={magicState}
-          onMagicChange={setMagicState}
-        />
-      </div>
+      <ShopProvider>
+        <div className="app">
+          <TopControls
+            listenersEnabled={listenersEnabled}
+            onToggleListeners={setListenersEnabled}
+            hiddenItemsVisible={hiddenItemsVisible}
+            onToggleHiddenItems={setHiddenItemsVisible}
+            onAutoSkill={handleAutoSkill}
+          />
+          <Tabs
+            listenersEnabled={listenersEnabled}
+            hiddenItemsVisible={hiddenItemsVisible}
+            magicState={magicState}
+            onMagicChange={setMagicState}
+          />
+        </div>
+      </ShopProvider>
     </CharacterProvider>
   );
 };

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import type { FormEvent } from "react";
 import {
   CharacterNameInput,
   ExperienceSection,
@@ -22,8 +21,9 @@ import { Roll, DiceChooser } from "../features/dice/services/dice";
 import { calculate, clearEqField, InToHTML } from "../features/dice/services/rechner";
 import VanillaMagicSystem from "../features/magic/VanillaMagicSystem";
 import type { MagicSystemState } from "../features/magic/types";
-import { addToInventoryFromInput, removeFromInventoryFromInput } from "../features/shop/services/shop";
-import { TheChoosenOne, wConvert, wReset } from "../features/shop/services/wallet";
+import InventoryPanel from "../features/shop/components/InventoryPanel";
+import ShopPanel from "../features/shop/components/ShopPanel";
+import WalletPanel from "../features/shop/components/WalletPanel";
 
 type TabKey = "charakter" | "magie" | "ausgeblendete" | "inventar" | "werkzeuge" | "einstellungen";
 
@@ -189,50 +189,7 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
                 </div>
               </div>
 
-              <div className="WalletContainer FlexItemContainer" id="WalletContainer">
-                <h6>Geldbeutel</h6>
-                <form id="inputField" onSubmit={(event: FormEvent<HTMLFormElement>) => event.preventDefault()}>
-                  <input type="number" placeholder="Enter a number" id="NumberInput" defaultValue={0} />
-                  <select name="Währund" id="CurrencyField">
-                    <option id="dukaten" value="dukaten">
-                      Dukaten
-                    </option>
-                    <option id="silber" value="silber">
-                      Silberlinge
-                    </option>
-                    <option id="heller" value="heller">
-                      Heller
-                    </option>
-                    <option id="kreuzer" value="kreuzer">
-                      Kreuzer
-                    </option>
-                  </select>
-                  <button type="submit" id="wadd" onClick={TheChoosenOne}>
-                    Add Wallet
-                  </button>
-                  <button type="submit" id="wconvert" onClick={wConvert}>
-                    Convert Wallet
-                  </button>
-
-                  <div style={{ marginTop: "20px" }}>
-                    <div>
-                      Dukaten: <p id="showDukaten"></p>
-                    </div>
-                    <div>
-                      Silberlinge: <p id="showSilber"></p>
-                    </div>
-                    <div>
-                      Heller: <p id="showHeller"></p>
-                    </div>
-                    <div>
-                      Kreuzer: <p id="showKreuzer"></p>
-                    </div>
-                  </div>
-                  <button type="submit" id="wReset" onClick={wReset} style={{ marginTop: "20px" }}>
-                    Reset Wallet
-                  </button>
-                </form>
-              </div>
+              <WalletPanel />
 
               <ExperienceSection onRecalculate={updateCharakterCalculation} listenersEnabled={listenersEnabled} />
             </div>
@@ -290,26 +247,8 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
         </div>
 
         <div className={`tab-content${activeTab === "inventar" ? " active" : ""}`} id="inventar-tab">
-          <div className="FlexItemContainer" id="ShopContainer">
-            <h6>Shop</h6>
-            <button type="button" id="ShopButton">
-              -
-            </button>
-            <div id="shop" className="shop-container"></div>
-          </div>
-          <div className="FlexItemContainer" id="InvContainer">
-            <h6>Inventar</h6>
-            <div>
-              <input type="text" id="itemNameInput" placeholder="Artikelname" />
-              <button type="button" onClick={addToInventoryFromInput}>
-                Hinzufügen
-              </button>
-              <button type="button" onClick={removeFromInventoryFromInput}>
-                Entfernen
-              </button>
-            </div>
-            <ul id="inventory" className="inventory-list"></ul>
-          </div>
+          <ShopPanel />
+          <InventoryPanel />
         </div>
 
         <div className={`tab-content${activeTab === "werkzeuge" ? " active" : ""}`} id="werkzeuge-tab">

--- a/src/features/character/services/saveLoader.ts
+++ b/src/features/character/services/saveLoader.ts
@@ -3,8 +3,7 @@ import { readNumericInput, readTextInput } from "./characterState";
 import { genCharInfo } from "./characterInfo";
 import { bindHideButtons } from "./hideButtons";
 import { updateCharakterCalculation } from "./calculations";
-import { initializeWallet, wallet } from "../../shop/services/wallet";
-import { renderInventory } from "../../shop/services/shop";
+import { createEmptyWallet, getShopSnapshot, normalizeInventoryItems, setShopSnapshot } from "../../shop/store";
 import type {
     CharacterData,
     CharacterInfo,
@@ -12,6 +11,7 @@ import type {
     InventoryItem,
     LoadCallbacks,
     MagicSystemSnapshot,
+    WalletState,
     SectionValues,
     SaveOverrides,
     TalentEntry,
@@ -99,6 +99,7 @@ export function saveCharacterData(data: CharacterData, overrides: SaveOverrides 
         // 4. Geldbeutel aktualisieren
         if (charakter.geld) {
             slLog("saveCharacterData: wallet -> charakter.geld");
+            const { wallet } = getShopSnapshot();
             charakter.geld = JSON.parse(JSON.stringify(wallet));
         } else {
             slLog("saveCharacterData: wallet sync übersprungen (charakter.geld oder wallet fehlt)");
@@ -227,27 +228,9 @@ function updateSpecialSection(section: TalentEntry[], sectionId: string) {
 // Hilfsfunktion: Speichert das Inventar
 function saveInventory(): InventoryItem[] {
     try {
-        const inventory: InventoryItem[] = [];
-        const items = document.querySelectorAll<HTMLLIElement>('#inventory li');
-        slLog("saveInventory: DOM items =", items.length);
-
-        items.forEach(item => {
-            const text = item.textContent;
-            if (!text) {
-                return;
-            }
-            const parts = text.split(' - ');
-
-            if (parts.length >= 2) {
-                const name = parts[0];
-                const quantityText = parts[1];
-                const quantity = parseInt(quantityText.replace('x', '')) || 1;
-
-                inventory.push({ name, quantity });
-            }
-        });
-
-        return inventory;
+        const { inventory } = getShopSnapshot();
+        slLog("saveInventory: snapshot items =", inventory.length);
+        return normalizeInventoryItems(inventory);
     } catch (error) {
         slErr("saveInventory: error", error);
         return [];
@@ -379,10 +362,16 @@ export function loadCharacterFile(file: File | null, callbacks: LoadCallbacks = 
             migrateToNewMagieSystem(data);
 
             // 2. Standard-Komponenten laden
-            if (typeof initializeWallet === 'function') {
-                slLog("handleFileUpload: initializeWallet()");
-                initializeWallet(data);
-            } else slWarn("handleFileUpload: initializeWallet fehlt");
+            slLog("handleFileUpload: setShopSnapshot()");
+            const currentSnapshot = getShopSnapshot();
+            const nextWallet = buildWalletSnapshot(data.charakter?.geld) ?? currentSnapshot.wallet;
+            const nextInventory = Array.isArray(data.inventory)
+                ? normalizeInventoryItems(data.inventory)
+                : currentSnapshot.inventory;
+            setShopSnapshot({
+                wallet: nextWallet,
+                inventory: nextInventory,
+            });
 
             if (typeof generateCharakterAttributes === 'function') {
                 slLog("handleFileUpload: generateCharakterAttributes()");
@@ -401,8 +390,7 @@ export function loadCharacterFile(file: File | null, callbacks: LoadCallbacks = 
 
             // 3. Inventar laden
             if (data.inventory) {
-                slLog("handleFileUpload: loadInventory(), items =", data.inventory.length);
-                loadInventory(data.inventory);
+                slLog("handleFileUpload: inventory geladen, items =", data.inventory.length);
             } else {
                 slLog("handleFileUpload: kein inventory im JSON");
             }
@@ -475,23 +463,20 @@ function loadXPAndLevel(
     }
 }
 
-// Hilfsfunktion: Lädt das Inventar
-function loadInventory(inventory: InventoryItem[]) {
-    try {
-        slLog("loadInventory: start, items =", Array.isArray(inventory) ? inventory.length : "n/a");
-        window.inventory = inventory.map(item => {
-            return {
-                name: item.name,
-                quantity: item.quantity || item.count || 0
-            };
-        });
-
-        slLog("loadInventory: renderInventory()");
-        renderInventory();
-    } catch (error) {
-        slErr("loadInventory: error", error);
+const buildWalletSnapshot = (geld?: WalletState) => {
+    if (!geld) {
+        return null;
     }
-}
+    const snapshot = createEmptyWallet();
+    snapshot.dukaten = geld.dukaten ?? 0;
+    snapshot.silber = geld.silber ?? 0;
+    snapshot.heller = geld.heller ?? 0;
+    snapshot.kreuzer = geld.kreuzer ?? 0;
+    snapshot.wInsg =
+        geld.wInsg ??
+        snapshot.dukaten * 1000 + snapshot.silber * 100 + snapshot.heller * 10 + snapshot.kreuzer;
+    return snapshot;
+};
 
 // Hilfsfunktion: Lädt das Magiesystem
 function loadMagieSystem(data: CharacterData) {

--- a/src/features/shop/ShopContext.tsx
+++ b/src/features/shop/ShopContext.tsx
@@ -1,0 +1,212 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import type { InventoryItem, ShopData, ShopItem, WalletState } from "../../types/character";
+import {
+  createEmptyWallet,
+  getShopSnapshot,
+  setShopSnapshot,
+  subscribeShopSnapshot,
+} from "./store";
+
+type WalletCurrency = "dukaten" | "silber" | "heller" | "kreuzer";
+
+type ShopContextValue = {
+  wallet: WalletState;
+  inventory: InventoryItem[];
+  shopData: ShopData;
+  shopLoading: boolean;
+  shopError: string | null;
+  addFunds: (amount: number, currency: WalletCurrency) => void;
+  convertWallet: () => void;
+  resetWallet: () => void;
+  buyItem: (item: ShopItem) => void;
+  addInventoryItem: (name: string, quantity?: number) => void;
+  removeInventoryItem: (name: string, quantity?: number) => void;
+};
+
+const ShopContext = createContext<ShopContextValue | null>(null);
+
+const currencyValues: Record<Capitalize<WalletCurrency>, number> = {
+  Dukaten: 1000,
+  Silber: 100,
+  Heller: 10,
+  Kreuzer: 1,
+};
+
+const getTotalInKreuzer = (wallet: WalletState) =>
+  wallet.dukaten * 1000 + wallet.silber * 100 + wallet.heller * 10 + wallet.kreuzer;
+
+const distributeWallet = (totalKreuzer: number): WalletState => {
+  const nextWallet = createEmptyWallet();
+  let remainder = Math.max(0, Math.floor(totalKreuzer));
+
+  nextWallet.dukaten = Math.floor(remainder / 1000);
+  remainder %= 1000;
+  nextWallet.silber = Math.floor(remainder / 100);
+  remainder %= 100;
+  nextWallet.heller = Math.floor(remainder / 10);
+  remainder %= 10;
+  nextWallet.kreuzer = Math.floor(remainder);
+  nextWallet.wInsg = totalKreuzer;
+
+  return nextWallet;
+};
+
+export const ShopProvider = ({ children }: { children: ReactNode }) => {
+  const initialSnapshot = getShopSnapshot();
+  const [wallet, setWallet] = useState<WalletState>(initialSnapshot.wallet);
+  const [inventory, setInventory] = useState<InventoryItem[]>(initialSnapshot.inventory);
+  const [shopData, setShopData] = useState<ShopData>({});
+  const [shopLoading, setShopLoading] = useState(true);
+  const [shopError, setShopError] = useState<string | null>(null);
+  const isApplyingSnapshot = useRef(false);
+
+  useEffect(() => {
+    return subscribeShopSnapshot((nextSnapshot) => {
+      isApplyingSnapshot.current = true;
+      setWallet(nextSnapshot.wallet);
+      setInventory(nextSnapshot.inventory);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isApplyingSnapshot.current) {
+      isApplyingSnapshot.current = false;
+      return;
+    }
+    setShopSnapshot({ wallet, inventory });
+  }, [wallet, inventory]);
+
+  useEffect(() => {
+    const loadShopData = async () => {
+      setShopLoading(true);
+      setShopError(null);
+      try {
+        const baseUrl = import.meta.env?.BASE_URL ?? "/";
+        const response = await fetch(`${baseUrl}shopData.json`);
+        if (!response.ok) {
+          throw new Error(`Fehler beim Laden der Shop-Daten: ${response.statusText}`);
+        }
+        const data = (await response.json()) as ShopData;
+        setShopData(data ?? {});
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("Fehler beim Laden der Shop-Daten:", error);
+        setShopError(message);
+      } finally {
+        setShopLoading(false);
+      }
+    };
+
+    void loadShopData();
+  }, []);
+
+  const addFunds = (amount: number, currency: WalletCurrency) => {
+    if (!Number.isFinite(amount) || amount <= 0) {
+      alert("Bitte eine gültige Zahl eingeben.");
+      return;
+    }
+    setWallet((current) => ({
+      ...current,
+      [currency]: current[currency] + amount,
+      wInsg: current.wInsg + amount * (currencyValues[capitalize(currency)] ?? 0),
+    }));
+  };
+
+  const convertWallet = () => {
+    setWallet((current) => distributeWallet(getTotalInKreuzer(current)));
+  };
+
+  const resetWallet = () => {
+    const response = prompt("Bitte 'reset' eingeben, um dein Geld zurückzusetzen");
+    if (response === "reset") {
+      setWallet(createEmptyWallet());
+    } else {
+      alert("Falsche Eingabe");
+    }
+  };
+
+  const addInventoryItem = (name: string, quantity = 1) => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      alert("Bitte einen gültigen Artikelnamen eingeben.");
+      return;
+    }
+    setInventory((current) => {
+      const existing = current.find((entry) => entry.name === trimmed);
+      if (existing) {
+        return current.map((entry) =>
+          entry.name === trimmed ? { ...entry, quantity: (entry.quantity ?? 0) + quantity } : entry
+        );
+      }
+      return [...current, { name: trimmed, quantity }];
+    });
+  };
+
+  const removeInventoryItem = (name: string, quantity = 1) => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      alert("Bitte einen gültigen Artikelnamen eingeben.");
+      return;
+    }
+    setInventory((current) => {
+      const existing = current.find((entry) => entry.name === trimmed);
+      if (!existing) {
+        alert("Artikel nicht im Inventar gefunden.");
+        return current;
+      }
+      const currentQuantity = existing.quantity ?? 0;
+      if (currentQuantity > quantity) {
+        return current.map((entry) =>
+          entry.name === trimmed ? { ...entry, quantity: currentQuantity - quantity } : entry
+        );
+      }
+      return current.filter((entry) => entry.name !== trimmed);
+    });
+  };
+
+  const buyItem = (item: ShopItem) => {
+    const price = Number(item.Preis) || 0;
+    const currencyValue = currencyValues[item.Währung as keyof typeof currencyValues];
+    const priceInKreuzer = Math.round(price * (currencyValue ?? 0));
+    const totalKreuzer = getTotalInKreuzer(wallet);
+
+    if (totalKreuzer < priceInKreuzer) {
+      alert("Nicht genug Geld! Der Kauf wurde abgebrochen.");
+      return;
+    }
+
+    const remaining = totalKreuzer - priceInKreuzer;
+    setWallet(distributeWallet(remaining));
+    addInventoryItem(item.Item, 1);
+  };
+
+  const value = useMemo(
+    () => ({
+      wallet,
+      inventory,
+      shopData,
+      shopLoading,
+      shopError,
+      addFunds,
+      convertWallet,
+      resetWallet,
+      buyItem,
+      addInventoryItem,
+      removeInventoryItem,
+    }),
+    [wallet, inventory, shopData, shopLoading, shopError]
+  );
+
+  return <ShopContext.Provider value={value}>{children}</ShopContext.Provider>;
+};
+
+export const useShop = () => {
+  const context = useContext(ShopContext);
+  if (!context) {
+    throw new Error("useShop must be used within ShopProvider");
+  }
+  return context;
+};
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);

--- a/src/features/shop/components/InventoryPanel.tsx
+++ b/src/features/shop/components/InventoryPanel.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useShop } from "../ShopContext";
+
+const InventoryPanel = () => {
+  const { inventory, addInventoryItem, removeInventoryItem } = useShop();
+  const [itemName, setItemName] = useState("");
+
+  return (
+    <div className="FlexItemContainer" id="InvContainer">
+      <h6>Inventar</h6>
+      <div>
+        <input
+          type="text"
+          value={itemName}
+          onChange={(event) => setItemName(event.target.value)}
+          placeholder="Artikelname"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            addInventoryItem(itemName);
+            setItemName("");
+          }}
+        >
+          Hinzufügen
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            removeInventoryItem(itemName);
+            setItemName("");
+          }}
+        >
+          Entfernen
+        </button>
+      </div>
+      <ul id="inventory" className="inventory-list">
+        {inventory.map((entry) => (
+          <li key={entry.name}>
+            {entry.name} - {(entry.quantity ?? entry.count ?? 0).toString()}x
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default InventoryPanel;

--- a/src/features/shop/components/ShopPanel.tsx
+++ b/src/features/shop/components/ShopPanel.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { useShop } from "../ShopContext";
+
+const ShopPanel = () => {
+  const { shopData, shopLoading, shopError, buyItem } = useShop();
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <div className="FlexItemContainer" id="ShopContainer">
+      <h6>Shop</h6>
+      <button type="button" onClick={() => setIsOpen((current) => !current)}>
+        {isOpen ? "-" : "+"}
+      </button>
+      {isOpen ? (
+        <div id="shop" className="shop-container">
+          {shopLoading ? <p>Shop-Daten werden geladen...</p> : null}
+          {shopError ? <p>Fehler: {shopError}</p> : null}
+          {!shopLoading &&
+            !shopError &&
+            Object.entries(shopData).map(([category, items]) => (
+              <div key={category}>
+                <h2 className="ShopHeader">{category}</h2>
+                {items.map((item) => (
+                  <div key={`${category}-${item.Item}`}>
+                    <p>
+                      {item.Item} - {item.Preis} {item.Währung}
+                    </p>
+                    <button type="button" onClick={() => buyItem(item)}>
+                      Kaufen
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ShopPanel;

--- a/src/features/shop/components/WalletPanel.tsx
+++ b/src/features/shop/components/WalletPanel.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { useShop } from "../ShopContext";
+
+const WalletPanel = () => {
+  const { wallet, addFunds, convertWallet, resetWallet } = useShop();
+  const [amount, setAmount] = useState(0);
+  const [currency, setCurrency] = useState<"dukaten" | "silber" | "heller" | "kreuzer">("dukaten");
+
+  return (
+    <div className="WalletContainer FlexItemContainer" id="WalletContainer">
+      <h6>Geldbeutel</h6>
+      <form
+        id="inputField"
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <input
+          type="number"
+          placeholder="Enter a number"
+          value={amount}
+          onChange={(event) => setAmount(Number(event.target.value))}
+        />
+        <select
+          name="Währund"
+          value={currency}
+          onChange={(event) => setCurrency(event.target.value as typeof currency)}
+        >
+          <option value="dukaten">Dukaten</option>
+          <option value="silber">Silberlinge</option>
+          <option value="heller">Heller</option>
+          <option value="kreuzer">Kreuzer</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => {
+            addFunds(amount, currency);
+            setAmount(0);
+          }}
+        >
+          Add Wallet
+        </button>
+        <button type="button" onClick={convertWallet}>
+          Convert Wallet
+        </button>
+
+        <div style={{ marginTop: "20px" }}>
+          <div>
+            Dukaten: <p>{wallet.dukaten}</p>
+          </div>
+          <div>
+            Silberlinge: <p>{wallet.silber}</p>
+          </div>
+          <div>
+            Heller: <p>{wallet.heller}</p>
+          </div>
+          <div>
+            Kreuzer: <p>{wallet.kreuzer}</p>
+          </div>
+        </div>
+        <button type="button" onClick={resetWallet} style={{ marginTop: "20px" }}>
+          Reset Wallet
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default WalletPanel;

--- a/src/features/shop/index.ts
+++ b/src/features/shop/index.ts
@@ -1,2 +1,2 @@
-export * from "./services/shop";
-export * from "./services/wallet";
+export * from "./ShopContext";
+export * from "./store";

--- a/src/features/shop/store.ts
+++ b/src/features/shop/store.ts
@@ -1,0 +1,52 @@
+import type { InventoryItem, WalletState } from "../../types/character";
+
+export type ShopSnapshot = {
+  wallet: WalletState;
+  inventory: InventoryItem[];
+};
+
+export const createEmptyWallet = (): WalletState => ({
+  dukaten: 0,
+  silber: 0,
+  heller: 0,
+  kreuzer: 0,
+  wInsg: 0,
+});
+
+const normalizeWallet = (wallet: WalletState): WalletState => ({
+  dukaten: Number(wallet.dukaten) || 0,
+  silber: Number(wallet.silber) || 0,
+  heller: Number(wallet.heller) || 0,
+  kreuzer: Number(wallet.kreuzer) || 0,
+  wInsg: Number(wallet.wInsg) || 0,
+});
+
+export const normalizeInventoryItems = (inventory: InventoryItem[]): InventoryItem[] =>
+  inventory.map((item) => ({
+    name: item.name,
+    quantity: item.quantity ?? item.count ?? 0,
+  }));
+
+let snapshot: ShopSnapshot = {
+  wallet: createEmptyWallet(),
+  inventory: [],
+};
+
+const listeners = new Set<(value: ShopSnapshot) => void>();
+
+export const getShopSnapshot = () => snapshot;
+
+export const setShopSnapshot = (next: ShopSnapshot) => {
+  snapshot = {
+    wallet: normalizeWallet(next.wallet),
+    inventory: normalizeInventoryItems(next.inventory ?? []),
+  };
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+export const subscribeShopSnapshot = (listener: (value: ShopSnapshot) => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 const loadLegacyScripts = async () => {
   await Promise.all([
     import("./features/character/legacy"),
-    import("./features/shop/legacy"),
     import("./features/dice/legacy"),
   ]);
 };


### PR DESCRIPTION
### Motivation
- Remove DOM-bound shop/wallet code and provide a React-driven API so Shop/Wallet can be used by components and the save/load pipeline without direct `document` access. 
- Progress the Codex migration plan (Codex-Aufgabe 6) by replacing legacy UI hooks with React state and components.

### Description
- Introduce a lightweight snapshot store and typed context: `src/features/shop/store.ts` and `src/features/shop/ShopContext.tsx` to hold wallet, inventory and shop data and to sync snapshots across non-React services. 
- Add React UI components `WalletPanel`, `ShopPanel`, `InventoryPanel` under `src/features/shop/components/` and wire them into `src/components/Tabs.tsx` so the Tabs UI uses the new components. 
- Update app bootstrap to provide the Shop context via `ShopProvider` in `src/App.tsx`, and stop loading the legacy shop bootstrap from `src/main.tsx`. 
- Adapt save/load logic in `src/features/character/services/saveLoader.ts` to read/write wallet and inventory through the new shop snapshot API and replace DOM-based inventory extraction with snapshot-backed serialization. 
- Update project documentation `DATEI_DOKUMENTATION.md` to reflect the new Shop/Wallet migration and added files.

### Testing
- Attempted to install dev dependencies with `npm install --include=dev --no-audit --no-fund --force`, which failed with an `ENOTEMPTY` rename error for `node_modules/eslint`, so dependency installation did not complete. (failed)
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but `vite` was not available because dev dependencies were not installed; server did not start. (failed)
- No automated unit/integration tests were executed due to the dependency installation failure, so runtime verification is pending once `npm install` succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c954d7aa0832c9c16f283b1858287)