### PR TITLE
Würfel & Rechner: React-Komponenten (DiceRoller, Calculator) und Tabs-Integration

### DIFF
--- a/DATEI_DOKUMENTATION.md
+++ b/DATEI_DOKUMENTATION.md
@@ -168,16 +168,20 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 
 ### Feature: Würfel & Rechner
 
+- **src/features/dice/components/DiceRoller.tsx**
+  - React-Komponente für das Würfelsystem inkl. Ergebnisanzeige.
+- **src/features/dice/components/Calculator.tsx**
+  - React-Komponente für den Taschenrechner (String-Ausdruck + `eval`).
 - **src/features/dice/index.ts**
   - Index/Exports für Würfel-Logik.
 - **src/features/dice/legacy.ts**
-  - Lädt die DOM-basierten Würfel-/Rechner-Skripte.
+  - Lädt die DOM-basierten Würfel-/Rechner-Skripte (Legacy-Referenz).
 - **src/features/dice/services/dice.ts**
-  - Würfelsystem inkl. d20/d100 Logik und Ergebnisanzeige.
+  - Würfelsystem inkl. d20/d100 Logik und Ergebnisanzeige (Legacy-Referenz).
 - **src/features/dice/services/spezialDice.ts**
-  - Experimentelle „gute/schlechte“ Würfel-Logik (Logging).
+  - Experimentelle „gute/schlechte“ Würfel-Logik (Logging, Legacy-Referenz).
 - **src/features/dice/services/rechner.ts**
-  - Taschenrechner (String-Ausdruck + `eval`).
+  - Taschenrechner (String-Ausdruck + `eval`, Legacy-Referenz).
 
 ### Gemeinsame Typen
 
@@ -210,13 +214,14 @@ Diese Dokumentation beschreibt die Aufgaben der Dateien im Repository **Pen-And-
 - React/Vite-Struktur inkl. Tabs, Header-Steuerung und globalem CharacterContext.
 - Magiesystem als React-Komponente (inkl. Typed State).
 - Charakterdaten-Speichern/-Laden (inkl. Migrationspfade) ist in TypeScript-Services vorhanden.
-- Shop/Würfel/Rechner-Logik wurde in Services ausgelagert und aus React heraus angesteuert.
+- Shop-Logik wurde in Services ausgelagert und aus React heraus angesteuert; Würfel/Rechner sind als React-Komponenten umgesetzt.
 - Legacy-Abhängigkeiten inventarisiert (Codex-Aufgabe 1) inkl. Skript zur Wiederholung der Analyse.
 - Erste React-State-Berechnungen für Kernattribute/Modifier inkl. abgeleiteter Basis-/Sonderwerte umgesetzt (Codex-Aufgabe 2 gestartet).
 - UI-Abschnitte für Attribute/Modifier/Sonderwerte/Kampf-Basiswerte in React-Komponenten ausgelagert (Codex-Aufgabe 3 gestartet).
 - Hide-Buttons/Min-Max-Aktionen für Attribute/Modifier nach React-State überführt (Codex-Aufgabe 4 gestartet).
 - Tabs rufen Legacy-Services direkt auf, statt globale `window`-Funktionen zu nutzen (Codex-Aufgabe 5 umgesetzt).
 - Shop/Inventar-UI und Wallet-Logik in React-State migriert, inkl. Shop-Data-Loading (Codex-Aufgabe 6 umgesetzt).
+- Würfel & Rechner als React-Komponenten umgesetzt, Legacy-Init in `main.tsx` entfernt (Codex-Aufgabe 7 umgesetzt).
 
 ### Was noch zu migrieren ist (weil aktuell noch Legacy-Skripte benötigt werden)
 
@@ -298,9 +303,9 @@ Da `src/main.tsx` weiterhin die Legacy-Skripte lädt und die Tabs `window`-Funkt
    - Migriere die DOM-gebundene Shop-/Wallet-Logik (`src/features/shop/services/*`) in React-State.
    - Baue das Shop-/Inventar-UI als komponentenbasierte Ansicht mit sauberem Datenfluss.
 
-7) **Codex-Aufgabe: Würfel & Rechner als React-Komponenten**
-   - Überführe `src/features/dice/services/*` in Komponenten mit lokalem State.
-   - Entferne `legacy.ts`-Abhängigkeiten und ersetze direkte DOM-Updates.
+7) **Codex-Aufgabe: Würfel & Rechner als React-Komponenten (erledigt)**
+   - `src/features/dice/services/*` in Komponenten mit lokalem State überführt.
+   - `legacy.ts`-Abhängigkeiten entfernt und direkte DOM-Updates ersetzt.
 
 8) **Codex-Aufgabe: Save/Load UI sauber modularisieren**
    - Nutze `SaveControls` und trenne Save/Load-UI von großen Tab-Markups.

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -17,8 +17,8 @@ import ModifiersSection from "../features/character/components/ModifiersSection"
 import SonderwerteSection from "../features/character/components/SonderwerteSection";
 import { updateCharakterCalculation } from "../features/character/services/calculations";
 import { changeColor, changeFont } from "../features/character/services/skin";
-import { Roll, DiceChooser } from "../features/dice/services/dice";
-import { calculate, clearEqField, InToHTML } from "../features/dice/services/rechner";
+import Calculator from "../features/dice/components/Calculator";
+import DiceRoller from "../features/dice/components/DiceRoller";
 import VanillaMagicSystem from "../features/magic/VanillaMagicSystem";
 import type { MagicSystemState } from "../features/magic/types";
 import InventoryPanel from "../features/shop/components/InventoryPanel";
@@ -252,97 +252,8 @@ const Tabs = ({ listenersEnabled, hiddenItemsVisible, magicState, onMagicChange 
         </div>
 
         <div className={`tab-content${activeTab === "werkzeuge" ? " active" : ""}`} id="werkzeuge-tab">
-          <div className="FlexItemContainer">
-            <h6>Würfelsystem</h6>
-            <div className="dice-controls">
-              <select id="Dicer" defaultValue="d20" onChange={DiceChooser}>
-                <option value="d100">W100</option>
-                <option value="d20">W20</option>
-                <option value="d10">W10</option>
-                <option value="d6">W6</option>
-                <option value="custom">Eigener Würfel</option>
-              </select>
-              <input type="number" id="DiceCount" defaultValue={1} min={1} max={20} />
-              <input type="number" id="DiceSides" defaultValue={20} min={2} max={1000} className="disNone" />
-              <button type="button" onClick={Roll}>
-                Würfeln
-              </button>
-            </div>
-            <div id="showDice" className="dice-results"></div>
-          </div>
-
-          <div className="FlexItemContainer calculator-container">
-            <h6>Rechner</h6>
-            <div id="calculator">
-              <div id="calc-display">
-                <div id="eqField" className="equation-field"></div>
-                <div id="evField" className="result-field"></div>
-              </div>
-              <div className="calculator-buttons">
-                <button type="button" onClick={clearEqField} className="calc-button function-button">
-                  C
-                </button>
-                <button type="button" onClick={() => InToHTML("(")} className="calc-button function-button">
-                  (
-                </button>
-                <button type="button" onClick={() => InToHTML(")")} className="calc-button function-button">
-                  )
-                </button>
-                <button type="button" onClick={() => InToHTML("/")} className="calc-button operator-button">
-                  /
-                </button>
-
-                <button type="button" onClick={() => InToHTML("7")} className="calc-button">
-                  7
-                </button>
-                <button type="button" onClick={() => InToHTML("8")} className="calc-button">
-                  8
-                </button>
-                <button type="button" onClick={() => InToHTML("9")} className="calc-button">
-                  9
-                </button>
-                <button type="button" onClick={() => InToHTML("*")} className="calc-button operator-button">
-                  ×
-                </button>
-
-                <button type="button" onClick={() => InToHTML("4")} className="calc-button">
-                  4
-                </button>
-                <button type="button" onClick={() => InToHTML("5")} className="calc-button">
-                  5
-                </button>
-                <button type="button" onClick={() => InToHTML("6")} className="calc-button">
-                  6
-                </button>
-                <button type="button" onClick={() => InToHTML("-")} className="calc-button operator-button">
-                  -
-                </button>
-
-                <button type="button" onClick={() => InToHTML("1")} className="calc-button">
-                  1
-                </button>
-                <button type="button" onClick={() => InToHTML("2")} className="calc-button">
-                  2
-                </button>
-                <button type="button" onClick={() => InToHTML("3")} className="calc-button">
-                  3
-                </button>
-                <button type="button" onClick={() => InToHTML("+")} className="calc-button operator-button">
-                  +
-                </button>
-
-                <button type="button" onClick={() => InToHTML("0")} className="calc-button">
-                  0
-                </button>
-                <button type="button" onClick={() => InToHTML(".")} className="calc-button">
-                  .
-                </button>
-                <button type="button" onClick={calculate} className="calc-button equal-button">
-                  =
-                </button>
-              </div>
-            </div>
-          </div>
+          <DiceRoller />
+          <Calculator />
         </div>
 
         <div className={`tab-content${activeTab === "einstellungen" ? " active" : ""}`} id="einstellungen-tab">

--- a/src/features/dice/components/Calculator.tsx
+++ b/src/features/dice/components/Calculator.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+
+const Calculator = () => {
+  const [equation, setEquation] = useState("");
+  const [result, setResult] = useState("");
+
+  const append = (value: string) => {
+    setEquation((current) => `${current}${value}`);
+    setResult("");
+  };
+
+  const clear = () => {
+    setEquation("");
+    setResult("");
+  };
+
+  const calculate = () => {
+    if (!equation.trim()) {
+      setResult("");
+      return;
+    }
+
+    try {
+      const calculation = eval(equation) as unknown;
+      setResult(String(calculation));
+    } catch {
+      setResult("Fehler");
+    }
+  };
+
+  return (
+    <div className="FlexItemContainer calculator-container">
+      <h6>Rechner</h6>
+      <div id="calculator">
+        <div id="calc-display">
+          <div id="eqField" className="equation-field">
+            {equation}
+          </div>
+          <div id="evField" className="result-field">
+            {result}
+          </div>
+        </div>
+        <div className="calculator-buttons">
+          <button type="button" onClick={clear} className="calc-button function-button">
+            C
+          </button>
+          <button type="button" onClick={() => append("(")} className="calc-button function-button">
+            (
+          </button>
+          <button type="button" onClick={() => append(")")} className="calc-button function-button">
+            )
+          </button>
+          <button type="button" onClick={() => append("/")} className="calc-button operator-button">
+            /
+          </button>
+
+          <button type="button" onClick={() => append("7")} className="calc-button">
+            7
+          </button>
+          <button type="button" onClick={() => append("8")} className="calc-button">
+            8
+          </button>
+          <button type="button" onClick={() => append("9")} className="calc-button">
+            9
+          </button>
+          <button type="button" onClick={() => append("*")} className="calc-button operator-button">
+            ×
+          </button>
+
+          <button type="button" onClick={() => append("4")} className="calc-button">
+            4
+          </button>
+          <button type="button" onClick={() => append("5")} className="calc-button">
+            5
+          </button>
+          <button type="button" onClick={() => append("6")} className="calc-button">
+            6
+          </button>
+          <button type="button" onClick={() => append("-")} className="calc-button operator-button">
+            -
+          </button>
+
+          <button type="button" onClick={() => append("1")} className="calc-button">
+            1
+          </button>
+          <button type="button" onClick={() => append("2")} className="calc-button">
+            2
+          </button>
+          <button type="button" onClick={() => append("3")} className="calc-button">
+            3
+          </button>
+          <button type="button" onClick={() => append("+")} className="calc-button operator-button">
+            +
+          </button>
+
+          <button type="button" onClick={() => append("0")} className="calc-button">
+            0
+          </button>
+          <button type="button" onClick={() => append(".")} className="calc-button">
+            .
+          </button>
+          <button type="button" onClick={calculate} className="calc-button equal-button">
+            =
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Calculator;

--- a/src/features/dice/components/DiceRoller.tsx
+++ b/src/features/dice/components/DiceRoller.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState } from "react";
+
+type DiceOption = {
+  value: string;
+  label: string;
+  sides: number | null;
+};
+
+const diceOptions: DiceOption[] = [
+  { value: "d100", label: "W100", sides: 100 },
+  { value: "d20", label: "W20", sides: 20 },
+  { value: "d10", label: "W10", sides: 10 },
+  { value: "d6", label: "W6", sides: 6 },
+  { value: "custom", label: "Eigener Würfel", sides: null },
+];
+
+const createResults = (count: number, sides: number) =>
+  Array.from({ length: count }, () => Math.floor(Math.random() * sides) + 1);
+
+const DiceResult = ({ result, sides }: { result: number; sides: number }) => {
+  const isMax = result === sides;
+  const isMin = result === 1;
+  const fill = isMax ? "#ff4122" : isMin ? "#1b7d4f" : "white";
+
+  return (
+    <svg
+      width={40}
+      height={40}
+      viewBox="0 0 100 100"
+      className={isMax ? "diceOutputMax" : isMin ? "diceOutputMin" : "diceOutput"}
+    >
+      <polygon
+        points="30,5 70,5 95,30 95,70 70,95 30,95 5,70 5,30"
+        stroke="black"
+        strokeWidth={5}
+        fill={fill}
+      />
+      <text
+        x="50"
+        y="50"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={40}
+        fontWeight="bold"
+        fill="black"
+      >
+        {result}
+      </text>
+    </svg>
+  );
+};
+
+const DiceRoller = () => {
+  const [diceType, setDiceType] = useState("d20");
+  const [diceCount, setDiceCount] = useState(1);
+  const [diceSides, setDiceSides] = useState(20);
+  const [results, setResults] = useState<number[]>([]);
+
+  const currentOption = useMemo(
+    () => diceOptions.find((option) => option.value === diceType) ?? diceOptions[1],
+    [diceType]
+  );
+
+  const handleTypeChange = (value: string) => {
+    setDiceType(value);
+    const option = diceOptions.find((item) => item.value === value);
+    if (option?.sides) {
+      setDiceSides(option.sides);
+    }
+  };
+
+  const handleRoll = () => {
+    const safeCount = Math.max(1, Math.min(20, Number.isNaN(diceCount) ? 1 : diceCount));
+    const safeSides = Math.max(2, Math.min(1000, Number.isNaN(diceSides) ? 20 : diceSides));
+    setResults(createResults(safeCount, safeSides));
+  };
+
+  return (
+    <div className="FlexItemContainer">
+      <h6>Würfelsystem</h6>
+      <div className="dice-controls">
+        <select value={diceType} onChange={(event) => handleTypeChange(event.target.value)}>
+          {diceOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          value={diceCount}
+          min={1}
+          max={20}
+          onChange={(event) => setDiceCount(Number(event.target.value))}
+        />
+        <input
+          type="number"
+          value={diceSides}
+          min={2}
+          max={1000}
+          className={currentOption.sides ? "disNone" : undefined}
+          onChange={(event) => setDiceSides(Number(event.target.value))}
+        />
+        <button type="button" onClick={handleRoll}>
+          Würfeln
+        </button>
+      </div>
+      <div className="dice-results">
+        {results.map((result, index) => (
+          <DiceResult key={`${result}-${index}`} result={result} sides={diceSides} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DiceRoller;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,10 +10,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 
 const loadLegacyScripts = async () => {
-  await Promise.all([
-    import("./features/character/legacy"),
-    import("./features/dice/legacy"),
-  ]);
+  await Promise.all([import("./features/character/legacy")]);
 };
 
 void loadLegacyScripts();


### PR DESCRIPTION
### Motivation
- Umsetzung von Codex-Aufgabe 7: Würfel- und Rechner-Logik aus DOM-getriebenen Services in lokal zustandsbasierte React-Komponenten überführen, um die Legacy-DOM-Abhängigkeiten zu reduzieren.
- Ziel war, die Werkzeuge im `Werkzeuge`-Tab als saubere Komponenten anzubieten und den Legacy-Bootstrap für Dice zu entfernen.

### Description
- Neue React-Komponenten `DiceRoller` und `Calculator` hinzugefügt unter `src/features/dice/components/` und im `Werkzeuge`-Tab in `src/components/Tabs.tsx` verwendet, wodurch die alten DOM-Handler ersetzt werden.
- Entferntes Legacy-Bootstrapping für das Dice-Modul in `src/main.tsx`, so dass nur noch die Charakter-Legacy-Init geladen wird.
- Projektdokumentation `DATEI_DOKUMENTATION.md` aktualisiert, um die neuen Komponenten und den erledigten Migrationsschritt zu reflektieren.
- Bestandene Legacy-Service-Dateien als Referenz belassen (keine Löschungen der Legacy-Service-Dateien in diesem PR).

### Testing
- `npm install` wurde ausgeführt und lief mit Warnungen (`Unknown env config

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c992412bc832cb781dc54a35be9ae)