### PR TITLE
Fix XP-driven level updates and talent input limits

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -72,6 +72,8 @@ const Tabs = () => {
   const attributeMax = Math.min(derived.level + 12, 21);
   const modifierMin = 0;
   const modifierMax = derived.level + 2;
+  const talentMin = -3;
+  const talentMax = Math.min(derived.level + 10, 21);
 
   const handleAttributeChange = (key: keyof typeof attributes, value: number) => {
     setAttributes((current) => ({ ...current, [key]: value }));
@@ -321,9 +323,16 @@ const Tabs = () => {
             <CombatTalentsSection
               talents={characterData?.charakter?.fähigkeiten?.Kampf_Talente}
               onChange={handleCombatTalentChange}
+              minValue={talentMin}
+              maxValue={talentMax}
             />
 
-            <TalentSections faehigkeiten={characterData?.charakter?.fähigkeiten} onChange={handleTalentChange} />
+            <TalentSections
+              faehigkeiten={characterData?.charakter?.fähigkeiten}
+              onChange={handleTalentChange}
+              minValue={talentMin}
+              maxValue={talentMax}
+            />
           </div>
         </div>
 

--- a/src/features/character/ExperienceSection.tsx
+++ b/src/features/character/ExperienceSection.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent } from "react";
 import { useCharacter } from "./CharacterContext";
+import { calculateLevelFromXp } from "./services/derivedCalculations";
 
 const ExperienceSection = () => {
   const { experience, setLevel, setXp, setSteigerungspunkte } = useCharacter();
@@ -24,7 +25,11 @@ const ExperienceSection = () => {
           className="stg attributeInput erfahrung"
           type="number"
           value={experience.xp}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => setXp(Number.parseInt(event.target.value, 10) || 0)}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            const nextXp = Number.parseInt(event.target.value, 10) || 0;
+            setXp(nextXp);
+            setLevel(calculateLevelFromXp(nextXp));
+          }}
           id="erfahrung_xp"
         />
         <span className="readonly-value">×</span>

--- a/src/features/character/components/CombatTalentsSection.tsx
+++ b/src/features/character/components/CombatTalentsSection.tsx
@@ -6,9 +6,11 @@ const sanitizeKey = (key: string) => key.replace(/\s+/g, "_");
 type CombatTalentsSectionProps = {
   talents?: CombatTalents;
   onChange: (talentName: string, index: number, value: number) => void;
+  minValue: number;
+  maxValue: number;
 };
 
-const CombatTalentsSection = ({ talents, onChange }: CombatTalentsSectionProps) => {
+const CombatTalentsSection = ({ talents, onChange, minValue, maxValue }: CombatTalentsSectionProps) => {
   const entries = Object.entries(talents ?? {});
 
   if (entries.length === 0) {
@@ -32,6 +34,8 @@ const CombatTalentsSection = ({ talents, onChange }: CombatTalentsSectionProps) 
                   className={`stg ArrAttributeInput Kampf_Talente Kampf_Talente_${index}`}
                   type="number"
                   value={safeValues[index] ?? 0}
+                  min={minValue}
+                  max={maxValue}
                   id={`Kampf_Talente_${sanitizedKey}_${index}`}
                   onChange={(event: ChangeEvent<HTMLInputElement>) =>
                     onChange(key, index, Number.parseInt(event.target.value, 10) || 0)

--- a/src/features/character/components/TalentSections.tsx
+++ b/src/features/character/components/TalentSections.tsx
@@ -15,13 +15,17 @@ type SectionKey = (typeof sectionDefinitions)[number]["key"];
 type TalentSectionsProps = {
   faehigkeiten?: CharacterFaehigkeiten;
   onChange: (section: SectionKey, index: number, value: number) => void;
+  minValue: number;
+  maxValue: number;
 };
 
 const renderTalentSection = (
   title: string,
   sectionId: SectionKey,
   entries: TalentEntry[] | undefined,
-  onChange: (section: SectionKey, index: number, value: number) => void
+  onChange: (section: SectionKey, index: number, value: number) => void,
+  minValue: number,
+  maxValue: number
 ) => {
   if (!Array.isArray(entries) || entries.length === 0) {
     return null;
@@ -42,6 +46,8 @@ const renderTalentSection = (
                 className={`stg attributeInput ${sectionId}`}
                 type="number"
                 value={entry.Wert ?? 0}
+                min={minValue}
+                max={maxValue}
                 id={`${sectionId}_${sanitizedName}`}
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   onChange(sectionId, index, Number.parseInt(event.target.value, 10) || 0)
@@ -55,10 +61,10 @@ const renderTalentSection = (
   );
 };
 
-const TalentSections = ({ faehigkeiten, onChange }: TalentSectionsProps) => (
+const TalentSections = ({ faehigkeiten, onChange, minValue, maxValue }: TalentSectionsProps) => (
   <div className="attributeFlexContainer">
     {sectionDefinitions.map((section) =>
-      renderTalentSection(section.title, section.key, faehigkeiten?.[section.key], onChange)
+      renderTalentSection(section.title, section.key, faehigkeiten?.[section.key], onChange, minValue, maxValue)
     )}
   </div>
 );

--- a/src/features/character/hooks/useCharacterCalculations.ts
+++ b/src/features/character/hooks/useCharacterCalculations.ts
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useCharacter } from "../CharacterContext";
 import {
   calculateDerivedValues,
-  calculateLevelFromXp,
   type CoreAttributes,
   type CoreModifiers,
 } from "../services/derivedCalculations";
@@ -32,16 +31,9 @@ const defaultModifiers: CoreModifiers = {
 };
 
 export const useCharacterCalculations = (magicSum: number) => {
-  const { experience, setLevel } = useCharacter();
+  const { experience } = useCharacter();
   const [attributes, setAttributes] = useState<CoreAttributes>(defaultAttributes);
   const [modifiers, setModifiers] = useState<CoreModifiers>(defaultModifiers);
-
-  useEffect(() => {
-    const nextLevel = calculateLevelFromXp(experience.xp);
-    if (experience.level !== nextLevel) {
-      setLevel(nextLevel);
-    }
-  }, [experience.level, experience.xp, setLevel]);
 
   const derived = useMemo(
     () =>


### PR DESCRIPTION
### Motivation
- Restore correct dynamic recalculations so derived values update predictably when inputs change, especially XP→level and special values (Sonderwerte). 
- Prevent automatic overwrites of manual level edits while keeping level consistent with XP when the user changes XP.

### Description
- Reworked XP handling: the XP input now sets XP and recalculates level directly using `calculateLevelFromXp` in `src/features/character/ExperienceSection.tsx`, and the automatic level-sync effect was removed from the calculations hook (`src/features/character/hooks/useCharacterCalculations.ts`).
- Enforced dynamic talent limits by computing `talentMin`/`talentMax` from `derived.level` in `src/components/Tabs.tsx` and passing them into talent components, and added `min`/`max` attributes to inputs in `src/features/character/components/CombatTalentsSection.tsx` and `src/features/character/components/TalentSections.tsx`.
- Minor cleanup: removed an unused import and simplified the hook to rely on the context `experience` so derived values recompute via React memoization (`useMemo`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cae09af04832c840335a066263df1)