### PR TITLE
Fix advancement point deduction on stat changes

### DIFF
--- a/src/features/character/services/inputListeners.ts
+++ b/src/features/character/services/inputListeners.ts
@@ -46,7 +46,7 @@ function removeInputChangeListeners() {
 
 function handleInputChange(event: Event) {
     const input = toInputElement(event.target);
-    const mainInput = document.getElementById('erfahrung_Gesteigerte');
+    const mainInput = document.getElementById('erfahrung_Steigerungspunkte');
     if (!input || !(mainInput instanceof HTMLInputElement)) {
         return;
     }
@@ -65,7 +65,7 @@ function handleInputChange(event: Event) {
             }
         });
 
-        const updatedValue = parseFloat(mainInput.value) + (diff * adjustmentValue);
+        const updatedValue = parseFloat(mainInput.value) - (diff * adjustmentValue);
         mainInput.value = String(updatedValue);
         input.setAttribute('data-initial', String(newValue));
         syncInputElement(input);
@@ -105,7 +105,7 @@ if (hiddenCheckbox) {
 function setInputsToMinOrMax(isMin: boolean) {
     // Alle Eingabefelder mit min und max finden
     const inputs = document.querySelectorAll('input[min][max]');
-    const mainInput = document.getElementById('erfahrung_Gesteigerte');
+    const mainInput = document.getElementById('erfahrung_Steigerungspunkte');
     let totalAdjustment = 0; // Variable für die Gesamtsumme der Änderungen
 
     inputs.forEach((input) => {
@@ -139,13 +139,13 @@ function setInputsToMinOrMax(isMin: boolean) {
         }
     });
 
-    // Hauptinput "erfahrung_Gesteigerte" aktualisieren
+    // Hauptinput "erfahrung_Steigerungspunkte" aktualisieren
     if (mainInput instanceof HTMLInputElement) {
-        mainInput.value = String(parseFloat(mainInput.value) + totalAdjustment);
+        mainInput.value = String(parseFloat(mainInput.value) - totalAdjustment);
         syncInputElement(mainInput);
     }
     updateCharakterCalculation()
-    alert(`Alle Eingaben wurden auf ${isMin ? 'Min' : 'Max'} gesetzt. Erfahrung gesteigerte wurde entsprechend angepasst.`);
+    alert(`Alle Eingaben wurden auf ${isMin ? 'Min' : 'Max'} gesetzt. Steigerungspunkte wurden entsprechend angepasst.`);
 }
 
 // Event-Listener für Buttons


### PR DESCRIPTION
### Motivation
- Stat increases were not reducing the available advancement pool because the input listener updated the wrong field and applied the change in the wrong direction.
- The adjustments table already defines per-class multipliers but the listener did not subtract costs from `steigerungspunkte` when fields were increased.

### Description
- Updated `src/features/character/services/inputListeners.ts` to target the `erfahrung_Steigerungspunkte` input instead of `erfahrung_Gesteigerte` for deductions.
- In `handleInputChange` the computed cost is now subtracted from the advancement points by changing `+ (diff * adjustment)` to `- (diff * adjustment)`.
- Adjusted the bulk `setInputsToMinOrMax` flow to subtract the aggregated `totalAdjustment` from `erfahrung_Steigerungspunkte` and updated the user alert text accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ebf59a78832ca9dc8138916a3ae9)