### PR TITLE
Dispatch input events for advancement updates, attach listeners on init, add tests

### DIFF
--- a/src/features/character/services/adjustments.ts
+++ b/src/features/character/services/adjustments.ts
@@ -29,43 +29,48 @@ export const adjustments: AdjustmentsMap = {
 
 
 // Anpassung der Steigerungswerte nach Klassen
+let cachedKlassenKategorien: KlassenKategorien | undefined;
+
 export function setKlassenVariable(selectedClass: string, klassenKategorien?: KlassenKategorien) {
-    if (!selectedClass || !klassenKategorien) return;
+    if (klassenKategorien) {
+        cachedKlassenKategorien = klassenKategorien;
+    }
+    const activeKategorien = klassenKategorien ?? cachedKlassenKategorien;
 
     // Zurücksetzen der adjustments auf Standardwerte
     resetAdjustmentsToDefault();
 
-    if (klassenKategorien["Magische Klassen"]?.includes(selectedClass)) {
+    if (selectedClass && activeKategorien?.["Magische Klassen"]?.includes(selectedClass)) {
         adjustments.modifier_magie = 3;
         adjustments.modifier_asp = 5;
         adjustments.Magische_Elemente = 20;
-    } else if (klassenKategorien["Nahkampf Basierte Klassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Nahkampf Basierte Klassen"]?.includes(selectedClass)) {
         adjustments.modifier_nahkampf = 3;
         adjustments.modifier_lp = 5;
         adjustments.attribute_Körperkraft = 3;
-    } else if (klassenKategorien["Fernkampf Basierte Klassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Fernkampf Basierte Klassen"]?.includes(selectedClass)) {
         adjustments.modifier_fernkampf = 3;
         adjustments.modifier_stealth = 5;
-    } else if (klassenKategorien["Wissenschaftliche Klassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Wissenschaftliche Klassen"]?.includes(selectedClass)) {
         adjustments.attribute_Klugheit = 3
         adjustments.Wissenschaftliche_Talente = 2;
-    } else if (klassenKategorien["Arbeiterklassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Arbeiterklassen"]?.includes(selectedClass)) {
         adjustments.Handwerkstalente = 2;
         adjustments.attribute = 4;
-    } else if (klassenKategorien["Halbmagische Klassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Halbmagische Klassen"]?.includes(selectedClass)) {
         adjustments.modifier_magie = 8;
         adjustments.modifier_asp = 8;
         adjustments.modifier_nahkampf = 8;
         adjustments.modifier_fernkampf = 8;
         adjustments.modifier_lp = 8;
         adjustments.Magische_Elemente = 23;
-    } else if (klassenKategorien["Stealth Klassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Stealth Klassen"]?.includes(selectedClass)) {
         adjustments.modifier_stealth = 3;
         adjustments.modifier_nahkampf = 8;
         adjustments.modifier_fernkampf = 8;
         adjustments.modifier_gift = 8;
         adjustments.Assassinen_Talente = 1;
-    } else if (klassenKategorien["Spezialklassen"]?.includes(selectedClass)) {
+    } else if (selectedClass && activeKategorien?.["Spezialklassen"]?.includes(selectedClass)) {
         adjustments.modifier_magie = 8;
         adjustments.modifier_asp = 8;
         adjustments.modifier_nahkampf = 8;

--- a/src/features/character/services/inputListeners.ts
+++ b/src/features/character/services/inputListeners.ts
@@ -6,7 +6,18 @@ import { updateCharakterCalculation } from "./calculations";
 const toInputElement = (target: EventTarget | null) =>
     target instanceof HTMLInputElement ? target : null;
 
+const setInputValueAndDispatch = (input: HTMLInputElement, nextValue: number) => {
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    if (valueSetter) {
+        valueSetter.call(input, String(nextValue));
+    } else {
+        input.value = String(nextValue);
+    }
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+};
+
 export function addInputChangeListeners() {
+    removeInputChangeListeners();
     const inputElements = document.querySelectorAll('.stg');
     inputElements.forEach((input) => {
         input.addEventListener('change', (event: Event) => {
@@ -46,7 +57,7 @@ function removeInputChangeListeners() {
 
 function handleInputChange(event: Event) {
     const input = toInputElement(event.target);
-    const mainInput = document.getElementById('erfahrung_Gesteigerte');
+    const mainInput = document.getElementById('erfahrung_Steigerungspunkte');
     if (!input || !(mainInput instanceof HTMLInputElement)) {
         return;
     }
@@ -65,8 +76,8 @@ function handleInputChange(event: Event) {
             }
         });
 
-        const updatedValue = parseFloat(mainInput.value) + (diff * adjustmentValue);
-        mainInput.value = String(updatedValue);
+        const updatedValue = parseFloat(mainInput.value) - (diff * adjustmentValue);
+        setInputValueAndDispatch(mainInput, updatedValue);
         input.setAttribute('data-initial', String(newValue));
         syncInputElement(input);
         syncInputElement(mainInput);
@@ -105,7 +116,7 @@ if (hiddenCheckbox) {
 function setInputsToMinOrMax(isMin: boolean) {
     // Alle Eingabefelder mit min und max finden
     const inputs = document.querySelectorAll('input[min][max]');
-    const mainInput = document.getElementById('erfahrung_Gesteigerte');
+    const mainInput = document.getElementById('erfahrung_Steigerungspunkte');
     let totalAdjustment = 0; // Variable für die Gesamtsumme der Änderungen
 
     inputs.forEach((input) => {
@@ -139,13 +150,13 @@ function setInputsToMinOrMax(isMin: boolean) {
         }
     });
 
-    // Hauptinput "erfahrung_Gesteigerte" aktualisieren
+    // Hauptinput "erfahrung_Steigerungspunkte" aktualisieren
     if (mainInput instanceof HTMLInputElement) {
-        mainInput.value = String(parseFloat(mainInput.value) + totalAdjustment);
+        setInputValueAndDispatch(mainInput, parseFloat(mainInput.value) - totalAdjustment);
         syncInputElement(mainInput);
     }
     updateCharakterCalculation()
-    alert(`Alle Eingaben wurden auf ${isMin ? 'Min' : 'Max'} gesetzt. Erfahrung gesteigerte wurde entsprechend angepasst.`);
+    alert(`Alle Eingaben wurden auf ${isMin ? 'Min' : 'Max'} gesetzt. Steigerungspunkte wurden entsprechend angepasst.`);
 }
 
 // Event-Listener für Buttons

--- a/src/features/character/services/liste.ts
+++ b/src/features/character/services/liste.ts
@@ -1,4 +1,5 @@
 import { setKlassenVariable } from "./adjustments";
+import { addInputChangeListeners } from "./inputListeners";
 import type { KlassenKategorien } from "../../../types/character";
 
 type InfoListeData = {
@@ -67,6 +68,8 @@ export const initializeListe = () => {
             if (initialClass) {
                 setKlassenVariable(initialClass, klassen);
             }
+
+            addInputChangeListeners();
         })
         .catch(error => console.error('Error fetching JSON:', error));
 };

--- a/tests/inputListeners.test.ts
+++ b/tests/inputListeners.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type ListenerMap = Record<string, Array<(event: Event) => void>>;
+
+class MockInput {
+  id = "";
+  value = "";
+  type = "number";
+  classList = new Set<string>();
+  private listeners: ListenerMap = {};
+  private attributes = new Map<string, string>();
+
+  constructor(id: string, value: number, classes: string[] = []) {
+    this.id = id;
+    this.value = String(value);
+    classes.forEach((cls) => this.classList.add(cls));
+  }
+
+  addEventListener(type: string, handler: (event: Event) => void) {
+    if (!this.listeners[type]) {
+      this.listeners[type] = [];
+    }
+    this.listeners[type].push(handler);
+  }
+
+  removeEventListener(type: string, handler: (event: Event) => void) {
+    if (!this.listeners[type]) {
+      return;
+    }
+    this.listeners[type] = this.listeners[type].filter((listener) => listener !== handler);
+  }
+
+  dispatchEvent(event: Event) {
+    const handlers = this.listeners[event.type] ?? [];
+    handlers.forEach((handler) => handler(event));
+    return true;
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+}
+
+test("input listeners deduct advancement points and dispatch input events", async () => {
+  const statInput = new MockInput("stat-input", 1, ["stg", "modifier_magie"]);
+  const mainInput = new MockInput("erfahrung_Steigerungspunkte", 100, ["stg"]);
+  let mainInputEvents = 0;
+  mainInput.addEventListener("input", () => {
+    mainInputEvents += 1;
+  });
+
+  (globalThis as { document?: unknown; HTMLInputElement?: unknown; Event?: unknown }).document = {
+    querySelectorAll: (selector: string) => {
+      if (selector === ".stg") {
+        return [statInput, mainInput];
+      }
+      if (selector === ".modifier_magie") {
+        return [statInput];
+      }
+      return [];
+    },
+    getElementById: (id: string) => {
+      if (id === "erfahrung_Steigerungspunkte") {
+        return mainInput;
+      }
+      return null;
+    },
+  };
+  (globalThis as { HTMLInputElement?: unknown }).HTMLInputElement = MockInput;
+  (globalThis as { Event?: unknown }).Event = class {
+    type: string;
+    bubbles: boolean;
+    constructor(type: string, options?: { bubbles?: boolean }) {
+      this.type = type;
+      this.bubbles = options?.bubbles ?? false;
+    }
+  };
+
+  const listenerModule = await import("../src/features/character/services/inputListeners.js");
+  listenerModule.addInputChangeListeners();
+
+  statInput.value = "2";
+  statInput.dispatchEvent({ type: "input", target: statInput } as unknown as Event);
+
+  assert.equal(mainInput.value, "90");
+  assert.equal(mainInputEvents, 1);
+});
+
+test("input listeners refund advancement points when values decrease", async () => {
+  const statInput = new MockInput("stat-input", 2, ["stg", "modifier_magie"]);
+  const mainInput = new MockInput("erfahrung_Steigerungspunkte", 90, ["stg"]);
+
+  (globalThis as { document?: unknown; HTMLInputElement?: unknown; Event?: unknown }).document = {
+    querySelectorAll: (selector: string) => {
+      if (selector === ".stg") {
+        return [statInput, mainInput];
+      }
+      if (selector === ".modifier_magie") {
+        return [statInput];
+      }
+      return [];
+    },
+    getElementById: (id: string) => {
+      if (id === "erfahrung_Steigerungspunkte") {
+        return mainInput;
+      }
+      return null;
+    },
+  };
+  (globalThis as { HTMLInputElement?: unknown }).HTMLInputElement = MockInput;
+  (globalThis as { Event?: unknown }).Event = class {
+    type: string;
+    bubbles: boolean;
+    constructor(type: string, options?: { bubbles?: boolean }) {
+      this.type = type;
+      this.bubbles = options?.bubbles ?? false;
+    }
+  };
+
+  const listenerModule = await import("../src/features/character/services/inputListeners.js");
+  listenerModule.addInputChangeListeners();
+
+  statInput.value = "1";
+  statInput.dispatchEvent({ type: "input", target: statInput } as unknown as Event);
+
+  assert.equal(mainInput.value, "100");
+});


### PR DESCRIPTION
### Motivation
- Advancement point updates performed directly on inputs did not emit `input` events, causing React/consumers to miss state changes and desync. 
- Input listeners could be missing on initial load and adjustments could be applied before class categories were available. 
- There were no automated tests covering advancement deductions/refunds and event dispatch behavior.

### Description
- Added a helper `setInputValueAndDispatch` in `src/features/character/services/inputListeners.ts` that sets an input's value via the native setter and dispatches an `input` event to keep external state in sync. 
- Updated advancement change handling to use the new helper so deductions and refunds trigger `input` events and call `syncInputElement`/`updateCharakterCalculation`. 
- Ensured listeners are attached on initialization by calling `addInputChangeListeners()` from `src/features/character/services/liste.ts` after the class/race lists are populated. 
- Cached class categories in `src/features/character/services/adjustments.ts` via `cachedKlassenKategorien` and guarded adjustment lookups on the cached/active categories, and re-attached listeners after adjustments are updated. 
- Added new unit tests `tests/inputListeners.test.ts` that verify advancement point deductions, refunds, and that `input` events are dispatched when values change.

### Testing
- Ran the project test suite with `npm test`, which runs `tsc -p tsconfig.test.json` and the Node tests, and all tests passed (6 tests, 0 failures). 
- The TypeScript test build performed as part of `npm test` completed successfully during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ebf59a78832ca9dc8138916a3ae9)